### PR TITLE
fix: 데이터 소스명 변경 및 현재 사용할 수 없는 Github Actions 삭제

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -25,15 +25,3 @@ jobs:
 
     - name: Build And Test Test
       run: ./gradlew clean bootJar
-        
-    - name: 테스트 결과를 PR에 코멘트로 등록합니다
-      uses: EnricoMi/publish-unit-test-result-action@v2
-      if: always()
-      with:
-        files: build/test-results/test/TEST-*.xml
-
-    - name: 테스트 실패 시, 실패한 코드 라인에 Check 코멘트를 등록합니다
-      uses: mikepenz/action-junit-report@v3
-      if: always()
-      with:
-        report_paths: build/test-results/test/TEST-*.xml

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -4,7 +4,7 @@ spring:
       on-profile: prod
 
   datasource:
-    url: jdbc:mysql://3.35.0.100:3306/heyyo?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&serverTimezone=UTC
+    url: jdbc:mysql://mysql:3306/heyyo?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&serverTimezone=UTC
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: root
     password: password


### PR DESCRIPTION
1. application-prod.yaml datasource url 변경 
- 따로 ec2 인스턴스를 만들어서 mysql 서버를 생성하였는데, 그럼 배포서버의 jar 파일이 mysql을 인식 못하는 현상이 있어서
- 기존 배포서버에 mysql 컨테이너 추가하고 링크 하였습니다.

2. github-actions 코드 수정
현재 build 후 테스트 데이터가 없어서 gitgub ci/cd가 테스트 실패라는 에러가 발생하여 관련 코드 삭제하였습니다. 