### PR TITLE
Hotfix : Production 인스턴스에서 DB와 서버가 연결이 안되는 에러 해결

### DIFF
--- a/src/main/java/com/team/heyyo/config/SpringSecurityConfig.java
+++ b/src/main/java/com/team/heyyo/config/SpringSecurityConfig.java
@@ -42,15 +42,12 @@ public class SpringSecurityConfig {
             .cors().disable()
             .httpBasic().disable()
             .sessionManagement()
-            .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-            // H2 콘솔 사용을 위한 설정
-            .and().headers(headers -> headers.frameOptions().sameOrigin());
+            .sessionCreationPolicy(SessionCreationPolicy.STATELESS);
 
         http.addFilterBefore(tokenAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
 
 //      토큰 재발급, 로그인 URL 은 열어두고, 나머지 API 는 인증 필요
         http.authorizeHttpRequests()
-                .requestMatchers(toH2Console()).permitAll()
                 .requestMatchers("/api/tokens", "/api/users/**").permitAll()
                 .anyRequest().authenticated();
 

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -4,7 +4,7 @@ spring:
       on-profile: prod
 
   datasource:
-    url: jdbc:mysql://mysql:3306/heyyo?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&serverTimezone=UTC
+    url: jdbc:mysql://110.9.137.34:3306/heyyo?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&serverTimezone=UTC
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: root
     password: password


### PR DESCRIPTION
## ✔ 지라 이슈 번호
HEY-39


## 📒 작업 내용
- H2 관련 Spring Security 가 에러를 일으켜서 삭제 
- Production 인스턴스에 굳이 mysql 까지 넣는건 아니라고 생각해서 일단 개인 서버로 url 맞춰두고 정상 작동하는 거 확인했습니다 현재 클라이언트 쪽에서도 빨리 작업을 진행하는게 좋을 것같고, 추후에 CI/CD를 수정하는 방안으로 가는게 좋다고 생각합니다. 

## 📢 리뷰어에게 하고 싶은 말
ex) 어디어디를 중점적으로 봐주세요 ...


## 📌 PR 전 체크 사항
- [x] base 브랜치가 **develop** 브랜치로 되어있나요?
- [x] PR title에 PR Type을 표시해 두었나요? (feat:, fix:, refact: ...)
- [x] test가 모두 통과 되었나요? 