### PR TITLE
feat: 회원가입 api 에 닉네임 추가, 닉네임 중복확인 구현, naver sms api를 활용한 SMS 인증 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,13 @@ dependencies {
     // Mail
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    //web-client 사용 위해
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    testImplementation 'io.projectreactor:reactor-test'
+    implementation 'org.apache.httpcomponents:httpcore:4.4.15'
+    implementation 'org.apache.httpcomponents:httpclient:4.5.13'
+    implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
 }
 
 tasks.named('test') {

--- a/src/docs/asciidoc/user.adoc
+++ b/src/docs/asciidoc/user.adoc
@@ -94,7 +94,7 @@ include::{snippets}/user/duplicate/email/path-parameters.adoc[]
 include::{snippets}/user/duplicate/email/http-response.adoc[]
 include::{snippets}/user/duplicate/email/response-fields.adoc[]
 
-=== 유저 이메일 중복확인 (중복된 이메일이 존재하는 경우)
+=== 유저 이메일 중복확인 실패 (중복된 이메일이 존재하는 경우)
 
 ==== Request
 
@@ -105,6 +105,50 @@ include::{snippets}/user/duplicate/email/fail/path-parameters.adoc[]
 
 include::{snippets}/user/duplicate/email/fail/http-response.adoc[]
 include::{snippets}/user/duplicate/email/fail/response-fields.adoc[]
+
+=== [성공] 유저 닉네임 중복 확인
+
+==== Request
+
+include::{snippets}/user/duplicate/nickname/success/http-request.adoc[]
+include::{snippets}/user/duplicate/nickname/success/path-parameters.adoc[]
+
+==== Response
+include::{snippets}/user/duplicate/nickname/success/http-response.adoc[]
+include::{snippets}/user/duplicate/nickname/success/response-fields.adoc[]
+
+=== [실패] 유저 닉네임 중복 확인 (중복된 이메일)
+
+==== Request
+
+include::{snippets}/user/duplicate/nickname/fail/http-request.adoc[]
+include::{snippets}/user/duplicate/nickname/fail/path-parameters.adoc[]
+
+==== Response
+
+include::{snippets}/user/duplicate/nickname/fail/http-response.adoc[]
+include::{snippets}/user/duplicate/nickname/fail/response-fields.adoc[]
+
+=== [성공] 입력된 전화번호로 메시지 전송
+
+==== Request
+include::{snippets}/user/sms/success/http-request.adoc[]
+include::{snippets}/user/sms/success/path-parameters.adoc[]
+
+=== Response
+
+include::{snippets}/user/sms/success/http-response.adoc[]
+include::{snippets}/user/sms/success/response-fields.adoc[]
+
+=== [실패] 입력된 전화번호로 메시지 전송
+
+==== Request
+include::{snippets}/user/sms/fail/http-request.adoc[]
+include::{snippets}/user/sms/fail/path-parameters.adoc[]
+
+==== Response
+include::{snippets}/user/sms/fail/http-response.adoc[]
+include::{snippets}/user/sms/fail/response-body.adoc[]
 
 === [성공] 유저 캐릭터 타입 전송
 
@@ -129,7 +173,7 @@ userCharacterType 에 아래의 값중 하나를 보내주시면 됩니다.
 ===== Header
 include::{snippets}/user/character-type/patch/success/request-headers.adoc[]
 
-=== Response
+==== Response
 
 include::{snippets}/user/character-type/patch/success/http-response.adoc[]
 

--- a/src/main/java/com/team/heyyo/sms/controller/SmsWebClient.java
+++ b/src/main/java/com/team/heyyo/sms/controller/SmsWebClient.java
@@ -1,0 +1,81 @@
+package com.team.heyyo.sms.controller;
+
+import com.team.heyyo.sms.dto.SmsResponseDto;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.tomcat.util.codec.binary.Base64;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.util.Optional;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+
+@Slf4j
+@Component
+public class SmsWebClient {
+
+    @Value("${naver-cloud-sms.accessKey}")
+    private String accessKey;
+
+    @Value("${naver-cloud-sms.secretKey}")
+    private String secretKey;
+
+    @Value("${naver-cloud-sms.serviceId}")
+    private String serviceId;
+
+    WebClient webClient = WebClient.create();
+
+    public Optional<SmsResponseDto> getSmsResponseDto(Long time, String payload) {
+        Mono<SmsResponseDto> smsResponseDtoMono = webClient.post()
+                .uri("https://sens.apigw.ntruss.com/sms/v2/services/" + serviceId + "/messages")
+                .contentType(APPLICATION_JSON)
+                .headers(httpHeaders -> {
+                    httpHeaders.setContentType(APPLICATION_JSON);
+                    httpHeaders.set("x-ncp-apigw-timestamp", time.toString());
+                    httpHeaders.set("x-ncp-iam-access-key", accessKey);
+                    httpHeaders.set("x-ncp-apigw-signature-v2", makeSignature(time));
+                })
+                .body(BodyInserters.fromValue(payload))
+                .retrieve()
+                .bodyToMono(SmsResponseDto.class);
+
+        return Optional.ofNullable(smsResponseDtoMono.block());
+    }
+
+    private String makeSignature(Long time)  {
+        try {
+            String space = " ";
+            String newLine = "\n";
+            String method = "POST";
+            String url = "/sms/v2/services/" + serviceId + "/messages";
+
+            String timestamp = time.toString();
+
+            String message = method +
+                    space +
+                    url +
+                    newLine +
+                    timestamp +
+                    newLine +
+                    accessKey;
+
+            SecretKeySpec signingKey = new SecretKeySpec(secretKey.getBytes(UTF_8), "HmacSHA256");
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(signingKey);
+
+            byte[] rawHmac = mac.doFinal(message.getBytes(UTF_8));
+
+            return Base64.encodeBase64String(rawHmac);
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        }
+        return "";
+
+    }
+}

--- a/src/main/java/com/team/heyyo/sms/dto/SmsMessageDto.java
+++ b/src/main/java/com/team/heyyo/sms/dto/SmsMessageDto.java
@@ -1,0 +1,10 @@
+package com.team.heyyo.sms.dto;
+
+public record SmsMessageDto(
+        String to,
+        String content
+) {
+    public static SmsMessageDto of(String to, String content) {
+        return new SmsMessageDto(to, content);
+    }
+}

--- a/src/main/java/com/team/heyyo/sms/dto/SmsResponseDto.java
+++ b/src/main/java/com/team/heyyo/sms/dto/SmsResponseDto.java
@@ -1,0 +1,18 @@
+package com.team.heyyo.sms.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Setter
+@Getter
+@Builder
+public class SmsResponseDto {
+    String requestId;
+    LocalDateTime requestTime;
+    String statusCode;
+    String statusName;
+    int certificationNumber;
+}

--- a/src/main/java/com/team/heyyo/sms/dto/ToSmsServerRequest.java
+++ b/src/main/java/com/team/heyyo/sms/dto/ToSmsServerRequest.java
@@ -1,0 +1,20 @@
+package com.team.heyyo.sms.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Setter
+@Getter
+@Builder
+public class ToSmsServerRequest {
+    String type;
+    String contentType;
+    String countryCode;
+    String from;
+    String content;
+    List<SmsMessageDto> messages;
+
+}

--- a/src/main/java/com/team/heyyo/sms/service/SmsService.java
+++ b/src/main/java/com/team/heyyo/sms/service/SmsService.java
@@ -1,0 +1,81 @@
+package com.team.heyyo.sms.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team.heyyo.sms.controller.SmsWebClient;
+import com.team.heyyo.sms.dto.SmsMessageDto;
+import com.team.heyyo.sms.dto.SmsResponseDto;
+import com.team.heyyo.sms.dto.ToSmsServerRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class SmsService {
+
+    private final ObjectMapper objectMapper;
+    private final SmsWebClient smsWebClient;
+
+    @Value("${naver-cloud-sms.senderPhone}")
+    private String phone;
+
+    WebClient webClient = WebClient.create();
+
+    public SmsResponseDto sendSmsToUserWithCertificationNumber(String to) {
+
+        int randomNumber = ThreadLocalRandom.current().nextInt(100000, 1000000);
+        String content = "HeyYo 인증번호 입니다. \n인증번호는 " + randomNumber + " 입니다.";
+
+        return sendSms(SmsMessageDto.of(to, content))
+                .map(responseDto -> {
+                    responseDto.setCertificationNumber(randomNumber);
+                    return responseDto;
+                })
+                .orElse(SmsResponseDto.builder()
+                        .statusCode("404")
+                        .build());
+    }
+
+    public Optional<SmsResponseDto> sendSms(SmsMessageDto smsMessageDto) {
+        try {
+            Long time = System.currentTimeMillis();
+
+            List<SmsMessageDto> messages = setMessagesToList(smsMessageDto);
+
+            ToSmsServerRequest smsPayload = setToSmsServerPayload(smsMessageDto, messages);
+            String payload = objectMapper.writeValueAsString(smsPayload);
+
+            return smsWebClient.getSmsResponseDto(time, payload);
+
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        }
+        return Optional.empty();
+    }
+
+    private ToSmsServerRequest setToSmsServerPayload(SmsMessageDto smsMessageDto, List<SmsMessageDto> messages) {
+        return ToSmsServerRequest.builder()
+                .type("SMS")
+                .contentType("COMM")
+                .countryCode("82")
+                .from(phone)
+                .content(smsMessageDto.content())
+                .messages(messages)
+                .build();
+    }
+
+    private List<SmsMessageDto> setMessagesToList(SmsMessageDto smsMessageDto) {
+        return new ArrayList<>(Collections.singleton(smsMessageDto));
+    }
+
+
+}

--- a/src/main/java/com/team/heyyo/user/constant/UserCharacterType.java
+++ b/src/main/java/com/team/heyyo/user/constant/UserCharacterType.java
@@ -1,8 +1,5 @@
 package com.team.heyyo.user.constant;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
 public enum UserCharacterType {
   고독,
   북적,

--- a/src/main/java/com/team/heyyo/user/constant/UserResponseCode.java
+++ b/src/main/java/com/team/heyyo/user/constant/UserResponseCode.java
@@ -11,6 +11,7 @@ public enum UserResponseCode {
   PASSWORD_NOT_MATCH(400, "비밀번호가 일치하지 않습니다."),
   EMAIL_NOT_FOUND(404, "해당 이메일과 일치하는 회원이 없습니다."),
   EMAIL_DUPLICATION(400, "이미 존재하는 이메일입니다."),
+  NICKNAME_DUPLICATION(400, "사용 불가능한 닉네임입니다."),
   NAME_PASSWORD_NOT_MATCH(404, "이름과 비밀번호와 일치하는 회원이 없습니다.");
 
   private final int status;

--- a/src/main/java/com/team/heyyo/user/controller/UserRegisterController.java
+++ b/src/main/java/com/team/heyyo/user/controller/UserRegisterController.java
@@ -1,25 +1,26 @@
 package com.team.heyyo.user.controller;
 
+import com.team.heyyo.sms.dto.SmsResponseDto;
+import com.team.heyyo.sms.service.SmsService;
 import com.team.heyyo.user.constant.UserResponseCode;
 import com.team.heyyo.user.dto.UserBaseResponse;
 import com.team.heyyo.user.dto.UserRegisterRequest;
 import com.team.heyyo.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @RequiredArgsConstructor
 @RequestMapping("/api/users")
 @RestController
 public class UserRegisterController {
 
   private final UserService userService;
+  private final SmsService smsService;
 
   @PostMapping("/register")
   public ResponseEntity<UserBaseResponse> register(
@@ -30,11 +31,25 @@ public class UserRegisterController {
 
   @GetMapping("/duplicate/emails/{email}")
   public ResponseEntity<UserBaseResponse> isEmailDuplicate(@PathVariable String email) {
-
     UserResponseCode responseCode = userService.isEmailDuplicate(email);
 
     return ResponseEntity.status(responseCode.getStatus())
         .body(UserBaseResponse.of(responseCode.getMessage()));
+  }
+
+  @GetMapping("/duplicate/nicknames/{nickname}")
+  public ResponseEntity<UserBaseResponse> isNicknameDuplicate(@PathVariable String nickname) {
+    UserResponseCode responseCode = userService.isNicknameDuplicate(nickname);
+
+    return ResponseEntity.status(responseCode.getStatus())
+            .body(UserBaseResponse.of(responseCode.getMessage()));
+  }
+
+  @GetMapping("/sms/{to}")
+  public ResponseEntity<SmsResponseDto> sendSmsTo(@PathVariable String to) {
+    SmsResponseDto smsResponseDto = smsService.sendSmsToUserWithCertificationNumber(to);
+
+    return ResponseEntity.status(Integer.parseInt(smsResponseDto.getStatusCode())).body(smsResponseDto);
   }
 }
 

--- a/src/main/java/com/team/heyyo/user/domain/User.java
+++ b/src/main/java/com/team/heyyo/user/domain/User.java
@@ -30,18 +30,20 @@ public class User implements UserDetails {
     @Column(nullable = false, unique = true)
     private String email;
 
+    private String nickname;
+
     private String name;
 
     private String password;
 
     private String phone;
 
+    private String recommendNickname;
+
     @Enumerated(EnumType.STRING)
     private Mbti mbtiType;
 
     private Date birth;
-
-    private String nickname;
 
     private Boolean isMarketingAgree;
 
@@ -52,8 +54,9 @@ public class User implements UserDetails {
     private UserCharacterType characterType;
 
     @Builder
-    public User(String email, String password, String name, UserRole role) {
+    public User(String email, String nickname, String password, String name, UserRole role) {
         this.email = email;
+        this.nickname = nickname;
         this.password = password;
         this.name = name;
         this.role = role;

--- a/src/main/java/com/team/heyyo/user/dto/UserRegisterRequest.java
+++ b/src/main/java/com/team/heyyo/user/dto/UserRegisterRequest.java
@@ -15,6 +15,9 @@ public class UserRegisterRequest {
     private String name;
 
     @NotNull
+    private String nickname;
+
+    @NotNull
     private String email;
 
     @NotNull
@@ -23,20 +26,21 @@ public class UserRegisterRequest {
     @NotNull
     private String phoneNumber;
 
-    private String recommendEmail;
+    private String recommendNickname;
 
-    private UserRegisterRequest(String name, String email, String password, String phoneNumber) {
+    private UserRegisterRequest(String name, String nickname, String email, String password, String phoneNumber) {
         this.name = name;
+        this.nickname = nickname;
         this.email = email;
         this.password = password;
         this.phoneNumber = phoneNumber;
     }
 
-    public static UserRegisterRequest of(String name, String email, String password, String phoneNumber) {
-        return new UserRegisterRequest(name, email, password, phoneNumber);
+    public static UserRegisterRequest of(String name, String nickname, String email, String password, String phoneNumber) {
+        return new UserRegisterRequest(name, nickname,email, password, phoneNumber);
     }
-    public static UserRegisterRequest of(String name, String email, String password, String phoneNumber, String recommendEmail) {
-        return new UserRegisterRequest(name, email, password, phoneNumber, recommendEmail);
+    public static UserRegisterRequest of(String name, String nickname, String email, String password, String phoneNumber, String recommendNickname) {
+        return new UserRegisterRequest(name ,nickname, email, password, phoneNumber, recommendNickname);
     }
 
 }

--- a/src/main/java/com/team/heyyo/user/repository/UserRepository.java
+++ b/src/main/java/com/team/heyyo/user/repository/UserRepository.java
@@ -11,4 +11,5 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
 
   Optional<User> findUserByEmailAndName(String email, String name);
 
+  Optional<User> findByNickname(String nickname);
 }

--- a/src/main/java/com/team/heyyo/user/service/UserService.java
+++ b/src/main/java/com/team/heyyo/user/service/UserService.java
@@ -26,11 +26,12 @@ public class UserService {
   public boolean register(UserRegisterRequest request) {
     userRepository.save(
         User.builder()
-            .email(request.getEmail())
-            .password(passwordEncoder.encode(request.getPassword()))
-            .name(request.getName())
-            .role(UserRole.USER)
-            .build()
+                .name(request.getName())
+                .nickname(request.getNickname())
+                .password(passwordEncoder.encode(request.getPassword()))
+                .email(request.getEmail())
+                .role(UserRole.USER)
+                .build()
     );
     return true;
   }
@@ -71,7 +72,6 @@ public class UserService {
     return userRepository.findByEmail(email)
         .map(user -> UserResponseCode.EMAIL_DUPLICATION)
         .orElse(UserResponseCode.SUCCESS);
-
   }
 
   public UserResponseCode findPasswordWithEmailAndName(String email, String name) {
@@ -89,4 +89,9 @@ public class UserService {
         .orElseThrow(() -> new UserNotFoundException("해당 email과 일치하는 사용자가 없습니다."));
   }
 
+  public UserResponseCode isNicknameDuplicate(String nickname) {
+    return userRepository.findByNickname(nickname)
+            .map(user -> UserResponseCode.NICKNAME_DUPLICATION)
+            .orElse(UserResponseCode.SUCCESS);
+  }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,5 +9,6 @@ spring:
       - submodule/application-oauth.yaml
       - submodule/application-jwt.yaml
       - submodule/application-mail.yaml
+      - submodule/application-sms.yaml
   profiles:
     default: local

--- a/src/test/java/com/team/heyyo/mail/service/MailServiceTest.java
+++ b/src/test/java/com/team/heyyo/mail/service/MailServiceTest.java
@@ -1,9 +1,6 @@
 package com.team.heyyo.mail.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.team.heyyo.config.QueryDslConfig;
-import com.team.heyyo.config.TestConfig;
 import com.team.heyyo.mail.constant.MailCode;
 import com.team.heyyo.mail.dto.MailMessage;
 import com.team.heyyo.user.domain.User;
@@ -11,11 +8,12 @@ import com.team.heyyo.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @Import(QueryDslConfig.class)

--- a/src/test/java/com/team/heyyo/sms/controller/SmsWebClientTest.java
+++ b/src/test/java/com/team/heyyo/sms/controller/SmsWebClientTest.java
@@ -1,0 +1,71 @@
+package com.team.heyyo.sms.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team.heyyo.sms.dto.SmsMessageDto;
+import com.team.heyyo.sms.dto.SmsResponseDto;
+import com.team.heyyo.sms.dto.ToSmsServerRequest;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class SmsWebClientTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private SmsWebClient smsWebClient;
+
+    @DisplayName("naver sms api 서버로 sms 요청을 보낸다.")
+    @Test
+    void sendRequestNaverSmsApi() throws JsonProcessingException {
+        //given
+        final String toPhoneNumber = "01073352306";
+        final String content = "테스트 메시지 입니다.";
+        final Long time = System.currentTimeMillis();
+
+        SmsMessageDto smsMessageDto = SmsMessageDto.of(toPhoneNumber, content);
+        List<SmsMessageDto> messages = setMessagesToList(smsMessageDto);
+
+        ToSmsServerRequest smsPayload = setToSmsServerPayload(smsMessageDto, messages);
+        String payload = objectMapper.writeValueAsString(smsPayload);
+
+        //when
+        Optional<SmsResponseDto> smsResponseDto = smsWebClient.getSmsResponseDto(time, payload);
+
+        //then
+        assertThat(smsResponseDto).isNotEmpty();
+        assertThat(smsResponseDto.get().getStatusCode()).isEqualTo("202");
+        assertThat(smsResponseDto.get().getStatusName()).isEqualTo("success");
+    }
+
+    private ToSmsServerRequest setToSmsServerPayload(SmsMessageDto smsMessageDto, List<SmsMessageDto> messages) {
+        return ToSmsServerRequest.builder()
+                .type("SMS")
+                .contentType("COMM")
+                .countryCode("82")
+                .from("01073352306")
+                .content(smsMessageDto.content())
+                .messages(messages)
+                .build();
+    }
+
+    private List<SmsMessageDto> setMessagesToList(SmsMessageDto smsMessageDto) {
+        return new ArrayList<>(Collections.singleton(smsMessageDto));
+    }
+
+
+}

--- a/src/test/java/com/team/heyyo/sms/service/SmsServiceTest.java
+++ b/src/test/java/com/team/heyyo/sms/service/SmsServiceTest.java
@@ -1,0 +1,74 @@
+package com.team.heyyo.sms.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team.heyyo.sms.controller.SmsWebClient;
+import com.team.heyyo.sms.dto.SmsResponseDto;
+import com.team.heyyo.sms.dto.ToSmsServerRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.doReturn;
+
+@ExtendWith(MockitoExtension.class)
+class SmsServiceTest {
+
+    @InjectMocks
+    SmsService smsService;
+
+    @Spy
+    ObjectMapper objectMapper;
+
+    @Mock
+    SmsWebClient smsWebClient;
+
+    @DisplayName("sms전송에 성공하면, SmsResponseDto의 statusCode에 202을 담아 리턴한다")
+    @Test
+    void sendSmsAndReturnSmsResponseDto() throws JsonProcessingException {
+        //given
+        final String toPhoneNumber ="01012341234";
+
+        doReturn("smsPayload")
+                .when(objectMapper).writeValueAsString(any(ToSmsServerRequest.class));
+        doReturn(Optional.of(SmsResponseDto.builder()
+                        .statusName("success")
+                        .statusCode("202")
+                        .build()))
+                .when(smsWebClient).getSmsResponseDto(anyLong(), anyString());
+
+        //when
+        SmsResponseDto smsResponseDto = smsService.sendSmsToUserWithCertificationNumber(toPhoneNumber);
+
+        //then
+        assertThat(smsResponseDto.getStatusCode()).isEqualTo("202");
+        assertThat(smsResponseDto.getStatusName()).isEqualTo("success");
+    }
+
+    @DisplayName("sms전송에 실패하면, SmsResponseDto의 statusCode에 404을 담아 리턴한다")
+    @Test
+    void sendSmsFail() throws JsonProcessingException {
+        //given
+        final String toPhoneNumber ="01012341234";
+
+        doReturn("smsPayload")
+                .when(objectMapper).writeValueAsString(any(ToSmsServerRequest.class));
+        doReturn(Optional.empty())
+                .when(smsWebClient).getSmsResponseDto(anyLong(), anyString());
+
+        //when
+        SmsResponseDto smsResponseDto = smsService.sendSmsToUserWithCertificationNumber(toPhoneNumber);
+
+        //then
+        assertThat(smsResponseDto.getStatusCode()).isEqualTo("404");
+    }
+
+}

--- a/src/test/java/com/team/heyyo/user/controller/UserRegisterControllerTest.java
+++ b/src/test/java/com/team/heyyo/user/controller/UserRegisterControllerTest.java
@@ -1,50 +1,48 @@
 package com.team.heyyo.user.controller;
 
-import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.team.heyyo.user.domain.User;
+import com.team.heyyo.sms.dto.SmsResponseDto;
+import com.team.heyyo.sms.service.SmsService;
+import com.team.heyyo.user.constant.UserResponseCode;
+import com.team.heyyo.user.dto.UserBaseResponse;
 import com.team.heyyo.user.dto.UserRegisterRequest;
-import com.team.heyyo.user.repository.UserRepository;
+import com.team.heyyo.user.service.UserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-@SpringBootTest
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 @AutoConfigureRestDocs
-@ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
-@MockBean(JpaMetamodelMappingContext.class)
-@WebAppConfiguration
+@ExtendWith({RestDocumentationExtension.class})
+@WebMvcTest(controllers = UserRegisterController.class)
 class UserRegisterControllerTest {
 
 
@@ -52,20 +50,20 @@ class UserRegisterControllerTest {
   ObjectMapper objectMapper;
 
   @Autowired
-  UserRepository userRepository;
-
-  @Autowired
-  PasswordEncoder encoder = new BCryptPasswordEncoder();
-
   MockMvc mockMvc;
 
+  @MockBean
+  UserService userService;
+
+  @MockBean
+  SmsService smsService;
+
   @BeforeEach
-  public void setup(WebApplicationContext webApplicationContext,
-      RestDocumentationContextProvider restDocumentation) {
+  public void init(WebApplicationContext webApplicationContext,
+                   RestDocumentationContextProvider restDocumentation) {
     this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
-        .apply(documentationConfiguration(restDocumentation))
-        .build();
-    userRepository.deleteAll();
+            .apply(documentationConfiguration(restDocumentation))
+            .build();
   }
 
   final String USER_API = "/api/users";
@@ -75,14 +73,15 @@ class UserRegisterControllerTest {
   void registerSuccess() throws Exception {
     //given
     final String api = USER_API + "/register";
-    UserRegisterRequest request = UserRegisterRequest.of("name", "test@email.com", "password",
+    UserRegisterRequest request = UserRegisterRequest.of("name", "nickname", "test@email.com", "password",
         "01012341234");
+
 
     //when
     final ResultActions resultActions = mockMvc.perform(
-        post(api)
-            .contentType(APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(request))
+            post(api)
+                    .contentType(APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
     ).andDo(print());
 
     //then
@@ -92,10 +91,11 @@ class UserRegisterControllerTest {
             preprocessResponse(prettyPrint()),
             requestFields(
                 fieldWithPath("name").description("유저 성함"),
-                fieldWithPath("email").description("유저 이메일"),
+                fieldWithPath("nickname").description("유저 닉네임"),
                 fieldWithPath("password").description("유저 비밀번호"),
+                fieldWithPath("email").description("유저 이메일"),
                 fieldWithPath("phoneNumber").description("유저 핸드폰 번호"),
-                fieldWithPath("recommendEmail").ignored()
+                fieldWithPath("recommendNickname").ignored()
             ),
             responseFields(
                 fieldWithPath("message").description("메시지")
@@ -111,6 +111,8 @@ class UserRegisterControllerTest {
     final String api = USER_API + "/duplicate/emails/{email}";
     final String email = "test@email.com";
 
+    doReturn(UserResponseCode.SUCCESS)
+            .when(userService).isEmailDuplicate(email);
     //when
     final ResultActions resultActions = mockMvc.perform(
         get(api, email)
@@ -137,14 +139,8 @@ class UserRegisterControllerTest {
     final String api = USER_API + "/duplicate/emails/{email}";
     final String duplicateEmail = "duplicateEmail@email.com";
 
-    userRepository.save(
-        User.builder()
-            .email(duplicateEmail)
-            .password("password")
-            .name("name")
-            .build()
-    );
-
+    doReturn(UserResponseCode.EMAIL_DUPLICATION)
+            .when(userService).isEmailDuplicate(duplicateEmail);
     //when
     final ResultActions resultActions = mockMvc.perform(
         get(api, duplicateEmail)
@@ -162,5 +158,155 @@ class UserRegisterControllerTest {
                 fieldWithPath("message").description("메시지")
             )
         ));
+  }
+
+  @DisplayName("닉네임 중복확인 성공")
+  @Test
+  void validateNicknameSuccess() throws Exception {
+    //given
+    final String api = USER_API + "/duplicate/nicknames/{nickname}";
+    final String nickname = "nickname";
+
+    doReturn(UserResponseCode.SUCCESS)
+            .when(userService).isNicknameDuplicate(nickname);
+    //when
+    final ResultActions resultActions = mockMvc.perform(
+            get(api, nickname)
+    ).andDo(print());
+
+    //then
+    resultActions.andExpect(status().isOk())
+            .andDo(document("user/duplicate/nickname/success",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(
+                            parameterWithName("nickname").description("중복확인할 닉네임")
+                    ),
+                    responseFields(
+                            fieldWithPath("message").description("메시지")
+                    )
+            ));
+
+    UserBaseResponse response = objectMapper.readValue(
+            resultActions.andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8),
+            UserBaseResponse.class
+    );
+    assertThat(response.message()).isEqualTo("성공");
+
+  }
+
+  @DisplayName("닉네임 중복확인 실패")
+  @WithMockUser(roles = "USER")
+  @Test
+  void duplicateNickname() throws Exception {
+    //given
+    final String api = USER_API + "/duplicate/nicknames/{nickname}";
+    final String duplicateNickname = "duplicateNickname";
+
+    doReturn(UserResponseCode.NICKNAME_DUPLICATION)
+            .when(userService).isNicknameDuplicate(duplicateNickname);
+    //when
+    final ResultActions resultActions = mockMvc.perform(
+            get(api, duplicateNickname)
+    ).andDo(print());
+
+    //then
+    resultActions.andExpect(status().isBadRequest())
+            .andDo(document("user/duplicate/nickname/fail",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(
+                            parameterWithName("nickname").description("중복확인할 닉네임")
+                    ),
+                    responseFields(
+                            fieldWithPath("message").description("메시지")
+                    )
+            ));
+
+    UserBaseResponse response = objectMapper.readValue(
+            resultActions.andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8),
+            UserBaseResponse.class
+    );
+    assertThat(response.message()).isEqualTo("사용 불가능한 닉네임입니다.");
+
+  }
+
+  @DisplayName("전화번호로 메시지 전송하기")
+  @Test
+  void sendSmsMessage() throws Exception {
+    //given
+    final String api = USER_API + "/sms/{to}";
+    final String phone = "01012341234";
+    int certificationNumber = 123123;
+
+    SmsResponseDto success = SmsResponseDto.builder()
+            .statusCode("202")
+            .statusName("success")
+            .requestId("requestId")
+            .requestTime(LocalDateTime.now())
+            .certificationNumber(certificationNumber)
+            .build();
+
+    doReturn(success)
+            .when(smsService).sendSmsToUserWithCertificationNumber(phone);
+    //when
+    ResultActions resultActions = mockMvc.perform(
+            get(api, phone)
+    ).andDo(print());
+
+    //then
+    resultActions.andExpect(status().isAccepted())
+            .andDo(document("user/sms/success",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(
+                            parameterWithName("to").description("sms 메시지를 보낼 사용자 휴대전화")
+                    ),
+                    responseFields(
+                            fieldWithPath("requestId").description("requestId"),
+                            fieldWithPath("requestTime").description("응답 시간"),
+                            fieldWithPath("statusCode").description("Http 응답 번호"),
+                            fieldWithPath("statusName").description("Http 응답 이름"),
+                            fieldWithPath("certificationNumber").description("인증번호")
+                    )
+            ));
+
+  }
+
+  @DisplayName("전화번호로 메시지 전송하기 실패 (sms 서버 에러)")
+  @Test
+  void failSendSmsMessage() throws Exception {
+    //given
+    final String api = USER_API + "/sms/{to}";
+    final String phone = "01012341234";
+
+    SmsResponseDto fail = SmsResponseDto.builder()
+            .statusCode("404")
+            .build();
+
+    doReturn(fail)
+            .when(smsService).sendSmsToUserWithCertificationNumber(phone);
+    //when
+    ResultActions resultActions = mockMvc.perform(
+            get(api, phone)
+    ).andDo(print());
+
+    //then
+    resultActions.andExpect(status().isNotFound())
+            .andDo(document("user/sms/fail",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(
+                            parameterWithName("to").description("sms 메시지를 보낼 사용자 휴대전화")
+                    ),
+                    responseFields(
+                            fieldWithPath("statusCode").description("Http 응답 번호"),
+                            fieldWithPath("requestId").description("requestId").ignored(),
+                            fieldWithPath("requestTime").description("응답 시간").ignored(),
+                            fieldWithPath("statusName").description("Http 응답 이름").ignored(),
+                            fieldWithPath("certificationNumber").description("인증번호").ignored()
+                    )
+            ));
+
   }
 }

--- a/src/test/java/com/team/heyyo/user/service/UserServiceTest.java
+++ b/src/test/java/com/team/heyyo/user/service/UserServiceTest.java
@@ -42,6 +42,7 @@ class UserServiceTest {
 
         UserRegisterRequest request = UserRegisterRequest.of(
                 "name",
+                "nickname",
                 "email",
                 "password",
                 "phoneNumber"
@@ -56,7 +57,7 @@ class UserServiceTest {
         assertThat(isRegistered).isTrue();
     }
 
-    @DisplayName("회원의 아이디와 비밀번호가 일치하면 true를 리턴한다.")
+    @DisplayName("로그인 시 회원의 아이디와 비밀번호가 일치하면 true를 리턴한다.")
     @Test
     void isEmailAndPasswordCorrect() {
         //given
@@ -76,7 +77,7 @@ class UserServiceTest {
         assertThat(userResponseCode).isEqualTo(UserResponseCode.SUCCESS);
     }
 
-    @DisplayName("회원의 아이디가 올바르지 않으면 에러를 던진다")
+    @DisplayName("회원의 이메일이 올바르지 않으면 에러를 던진다")
     @Test
     void emailNotFound() {
         //given
@@ -113,6 +114,36 @@ class UserServiceTest {
 
         //then
         assertThat(userResponseCode).isEqualTo(UserResponseCode.PASSWORD_NOT_MATCH);
+    }
+
+    @DisplayName("닉네임이 저장되어있으면 UserResponseCode SUCCESS를 반환한다.")
+    @Test
+    void isNicknameDuplicate() {
+        //given
+        final String duplicateNickname = "nickname";
+
+        doReturn(Optional.empty())
+                .when(userRepository).findByNickname(duplicateNickname);
+        //when
+        UserResponseCode successResponseCode = userService.isNicknameDuplicate(duplicateNickname);
+
+        //then
+        assertThat(successResponseCode).isEqualTo(UserResponseCode.SUCCESS);
+    }
+
+    @DisplayName("닉네임이 저장되어있으면 UserResponseCode NICKNAME_DUPLICATION을 반환한다.")
+    @Test
+    void isNicknameNotDuplicate() {
+        //given
+        final String duplicateNickname = "nickname";
+
+        doReturn(Optional.of(User.builder().build()))
+                .when(userRepository).findByNickname(duplicateNickname);
+        //when
+        UserResponseCode successResponseCode = userService.isNicknameDuplicate(duplicateNickname);
+
+        //then
+        assertThat(successResponseCode).isEqualTo(UserResponseCode.NICKNAME_DUPLICATION);
     }
 
 }


### PR DESCRIPTION
## ✔ 지라 이슈 번호
HEY-42

## 📒 작업 내용
- 회원 가입 api 에 닉네임 추가 
- 닉네임 중복확인 구현 
- naver sms api를 활용하여 SMS 인증 구현 
-> naver sms api로 요청하는 부분은 WebClient를 활용하여 구현

## 📢 리뷰어에게 하고 싶은 말
ex) 어디어디를 중점적으로 봐주세요 ...


## 📌 PR 전 체크 사항
- [x] base 브랜치가 **develop** 브랜치로 되어있나요?
- [x] PR title에 PR Type을 표시해 두었나요? (feat:, fix:, refact: ...)
- [x] test가 모두 통과 되었나요? 