### PR TITLE
hotfix: 배포서버 profile 인식 오류 문제 해결 

### DIFF
--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -1,0 +1,20 @@
+spring:
+  config:
+    activate:
+      on-profile: local
+
+  datasource:
+    url: jdbc:h2:mem:db;MODE=MYSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: root
+  h2:
+    console:
+      enabled: true
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+  sql.init.mode: always

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,0 +1,8 @@
+spring:
+  config:
+    activate:
+      on-profile: prod
+    import:
+      - submodule/application-db.yaml
+
+


### PR DESCRIPTION
## ✔ 지라 이슈 번호
HEY-48

## 📒 작업 내용
- 배포서버에서 profile 이 submodule 폴더 안에 존재하니 인식이 안되고 h2 db로 실행되는 문제 발생 
- submodule 로 분리한 local, prod yaml 파일을 기존 resource 경로로 이동후 
- db 접속 정보는 submodule 로 분리

## 📢 리뷰어에게 하고 싶은 말
ex) 어디어디를 중점적으로 봐주세요 ...


## 📌 PR 전 체크 사항
- [x] base 브랜치가 **develop** 브랜치로 되어있나요?
- [x] PR title에 PR Type을 표시해 두었나요? (feat:, fix:, refact: ...)
- [x] test가 모두 통과 되었나요? 