### PR TITLE
feat: 그룹공부방 페이지에 해당하는 api 구현

### DIFF
--- a/src/docs/asciidoc/groupStudy.adoc
+++ b/src/docs/asciidoc/groupStudy.adoc
@@ -10,6 +10,8 @@ link:index.html[메인 문서]
 
 == GroupStudy API
 
+== 그룹 공부방0 페이지 API
+
 === 최근에 생긴 그룹공부방 리스트 가져오기 (12개)
 
 ==== Request
@@ -33,3 +35,67 @@ include::{snippets}/group-study/getBestGroupStudyList/success/request-headers.ad
 
 include::{snippets}/group-study/getBestGroupStudyList/success/http-response.adoc[]
 include::{snippets}/group-study/getBestGroupStudyList/success/response-fields.adoc[]
+
+== 그룹 공부방 페이지 API
+
+=== MBTI (그룹공부방0 의 키워드와 일치) - 여기서 앞 영어 부분만 보면 됩니다!
+==== 앞의 영어부분에 따라서 api에서 mbti 부분에 넣어주시면 됩니다.
+Loneliness("고독해요");
+
+Communication("소통해요");
+
+Crowded("북적해요");
+
+Quiet("한산해요");
+
+Researching("연구해요");
+
+Useful("유익해요");
+
+Timid("소심해요");
+
+Focus("집중해요");
+
+=== 키워드에 따른 최근에 생긴 그룹 공부방 리스트 가져오기 (6개)
+
+==== Request
+
+include::{snippets}/group-study/getRecentMbtiGroupStudyList/success/http-request.adoc[]
+===== requestHeader
+include::{snippets}/group-study/getRecentMbtiGroupStudyList/success/request-headers.adoc[]
+===== pathParameter
+include::{snippets}/group-study/getRecentMbtiGroupStudyList/success/path-parameters.adoc[]
+
+==== Response
+
+include::{snippets}/group-study/getRecentMbtiGroupStudyList/success/http-response.adoc[]
+include::{snippets}/group-study/getRecentMbtiGroupStudyList/success/response-fields.adoc[]
+
+=== 키워드에 해당하는 좋아요를 가장 많이 받은 그룹 공부방 리스트 가져오기 (6개)
+
+==== Request
+
+include::{snippets}/group-study/getMostLikeMbtiList/success/http-request.adoc[]
+===== pathParameter
+include::{snippets}/group-study/getMostLikeMbtiList/success/path-parameters.adoc[]
+===== requestHeader
+include::{snippets}/group-study/getMostLikeMbtiList/success/request-headers.adoc[]
+
+
+==== Response
+
+include::{snippets}/group-study/getMostLikeMbtiList/success/http-response.adoc[]
+include::{snippets}/group-study/getMostLikeMbtiList/success/response-fields.adoc[]
+
+=== 로그인한 사용자의 MBTI(keyword) 와 반대되는 그룹공부방 리스트 가져오기 (8개)
+
+==== Request
+
+include::{snippets}/group-study/getOppositeMbtiGroupStudyList/success/http-request.adoc[]
+===== requestHeader
+include::{snippets}/group-study/getOppositeMbtiGroupStudyList/success/request-headers.adoc[]
+
+==== Response
+
+include::{snippets}/group-study/getOppositeMbtiGroupStudyList/success/http-response.adoc[]
+include::{snippets}/group-study/getOppositeMbtiGroupStudyList/success/response-fields.adoc[]

--- a/src/main/java/com/team/heyyo/group/study/controller/GroupStudyController.java
+++ b/src/main/java/com/team/heyyo/group/study/controller/GroupStudyController.java
@@ -1,12 +1,14 @@
 package com.team.heyyo.group.study.controller;
 
 import com.team.heyyo.common.AccessToken;
-import com.team.heyyo.group.study.dto.GroupStudyResponse;
-import com.team.heyyo.group.study.service.GroupStudyService;
+import com.team.heyyo.group.study.dto.GroupStudyListResponse;
+import com.team.heyyo.group.study.service.GroupStudyDetailPageListService;
+import com.team.heyyo.group.study.service.GroupStudyMainPageListService;
+import com.team.heyyo.user.constant.Mbti;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,18 +19,45 @@ import java.util.List;
 @RestController
 public class GroupStudyController {
 
-    private final GroupStudyService groupStudyService;
+    private final GroupStudyMainPageListService groupStudyMainPageListService;
+    private final GroupStudyDetailPageListService groupStudyDetailPageListService;
 
     @GetMapping("/recent")
-    public ResponseEntity<List<GroupStudyResponse>> getRecentGroupStudyList(@AccessToken String accessToken) {
+    public ResponseEntity<List<GroupStudyListResponse>> getRecentGroupStudyList(@AccessToken String accessToken) {
 
-        List<GroupStudyResponse> recentGroupStudyList = groupStudyService.getRecentGroupStudyList(accessToken);
+        List<GroupStudyListResponse> recentGroupStudyList = groupStudyMainPageListService.getRecentGroupStudyList(accessToken);
         return ResponseEntity.ok(recentGroupStudyList);
     }
 
     @GetMapping("/best")
-    public ResponseEntity<List<GroupStudyResponse>> getBestGroupStudyList(@AccessToken String accessToken) {
-        List<GroupStudyResponse> bestGroupListFromToday = groupStudyService.getBestGroupStudyListFromToday(accessToken);
+    public ResponseEntity<List<GroupStudyListResponse>> getBestGroupStudyList(@AccessToken String accessToken) {
+        List<GroupStudyListResponse> bestGroupListFromToday = groupStudyMainPageListService.getBestGroupStudyListFromToday(accessToken);
         return ResponseEntity.ok(bestGroupListFromToday);
+    }
+
+    @GetMapping("/detail/recent/{mbti}")
+    public ResponseEntity<List<GroupStudyListResponse>> getRecentMbtiGroupStudyList(
+            @AccessToken String accessToken,
+            @PathVariable Mbti mbti
+    ) {
+        List<GroupStudyListResponse> groupStudyDetailList = groupStudyDetailPageListService.getRecentGroupStudyDetailList(accessToken, mbti);
+        return ResponseEntity.ok(groupStudyDetailList);
+    }
+
+    @GetMapping("/detail/best/{mbti}")
+    public ResponseEntity<List<GroupStudyListResponse>> getBestMbtiGroupStudyList(
+            @AccessToken String accessToken,
+            @PathVariable Mbti mbti
+    ) {
+        List<GroupStudyListResponse> groupStudyDetailList = groupStudyDetailPageListService.getMostLikeGroupStudyDetailList(accessToken, mbti);
+        return ResponseEntity.ok(groupStudyDetailList);
+    }
+
+    @GetMapping("/detail/opposite")
+    public ResponseEntity<List<GroupStudyListResponse>> getBestMbtiGroupStudyList(
+            @AccessToken String accessToken
+    ) {
+        List<GroupStudyListResponse> groupStudyDetailList = groupStudyDetailPageListService.getOppositeUserMbtiGroupStudyList(accessToken);
+        return ResponseEntity.ok(groupStudyDetailList);
     }
 }

--- a/src/main/java/com/team/heyyo/group/study/dto/GroupStudyListResponse.java
+++ b/src/main/java/com/team/heyyo/group/study/dto/GroupStudyListResponse.java
@@ -8,7 +8,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
-public class GroupStudyResponse{
+public class GroupStudyListResponse {
 
 
     private String title;
@@ -16,7 +16,7 @@ public class GroupStudyResponse{
     private int viewerCount;
     private boolean isLiked;
 
-    public static GroupStudyResponse of(String title, List<String> tags, int viewerCount, boolean isLiked) {
-        return new GroupStudyResponse(title, tags, viewerCount, isLiked);
+    public static GroupStudyListResponse of(String title, List<String> tags, int viewerCount, boolean isLiked) {
+        return new GroupStudyListResponse(title, tags, viewerCount, isLiked);
     }
 }

--- a/src/main/java/com/team/heyyo/group/study/repository/groupstudy/GroupStudyRepositoryCustom.java
+++ b/src/main/java/com/team/heyyo/group/study/repository/groupstudy/GroupStudyRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.team.heyyo.group.study.repository.groupstudy;
 
 import com.team.heyyo.group.study.domain.GroupStudy;
+import com.team.heyyo.user.constant.Mbti;
 
 import java.util.List;
 
@@ -8,6 +9,10 @@ public interface GroupStudyRepositoryCustom {
     public List<GroupStudy> selectRecentGroupStudies();
 
     public List<GroupStudy> findGroupStudiesOrderedByMostLikesFromToday();
+    public List<GroupStudy> selectRecentGroupStudyDetailListWithMbti(Long userId, Mbti mbti, int limit);
 
+    List<GroupStudy> selectMostLikeGroupStudyDetailListWithMbti(Long userId, Mbti mbti, int limit);
+
+    List<GroupStudy> selectOppositeUserMbtiGroupStudyList(Long userId, int limit);
 }
 

--- a/src/main/java/com/team/heyyo/group/study/service/GroupStudyDetailPageListService.java
+++ b/src/main/java/com/team/heyyo/group/study/service/GroupStudyDetailPageListService.java
@@ -1,0 +1,87 @@
+package com.team.heyyo.group.study.service;
+
+import com.team.heyyo.auth.jwt.support.TokenProvider;
+import com.team.heyyo.group.study.domain.GroupStudy;
+import com.team.heyyo.group.study.dto.GroupStudyListResponse;
+import com.team.heyyo.group.study.repository.groupstudy.GroupStudyRepository;
+import com.team.heyyo.group.study.repository.groupstudylike.GroupStudyLikeRepository;
+import com.team.heyyo.group.study.repository.groupstudytag.GroupStudyTagRepository;
+import com.team.heyyo.user.constant.Mbti;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+@RequiredArgsConstructor
+@Service
+public class GroupStudyDetailPageListService {
+
+    private final GroupStudyRepository groupStudyRepository;
+    private final GroupStudyTagRepository groupStudyTagRepository;
+    private final GroupStudyLikeRepository groupStudyLikeRepository;
+    private final TokenProvider tokenProvider;
+
+    public List<GroupStudyListResponse> getRecentGroupStudyDetailList(String accessToken, Mbti mbti) {
+        int randomNumber = getRandomNumber();
+        Long userId = tokenProvider.getUserId(accessToken);
+
+        List<GroupStudyListResponse> groupStudyListResponseList = new ArrayList<>();
+        List<GroupStudy> groupStudies = groupStudyRepository.selectRecentGroupStudyDetailListWithMbti(userId, mbti, 6);
+
+        return getGroupStudyListResponses(randomNumber, userId, groupStudyListResponseList, groupStudies);
+    }
+
+    public List<GroupStudyListResponse> getMostLikeGroupStudyDetailList(String accessToken, Mbti mbti) {
+        int randomNumber = getRandomNumber();
+        Long userId = tokenProvider.getUserId(accessToken);
+
+        List<GroupStudyListResponse> groupStudyListResponseList = new ArrayList<>();
+        List<GroupStudy> groupStudies = groupStudyRepository.selectMostLikeGroupStudyDetailListWithMbti(userId, mbti, 6);
+
+        return getGroupStudyListResponses(randomNumber, userId, groupStudyListResponseList, groupStudies);
+    }
+
+    public List<GroupStudyListResponse> getOppositeUserMbtiGroupStudyList(String accessToken) {
+        int randomNumber = getRandomNumber();
+        Long userId = tokenProvider.getUserId(accessToken);
+
+        List<GroupStudyListResponse> groupStudyListResponseList = new ArrayList<>();
+        List<GroupStudy> groupStudies = groupStudyRepository.selectOppositeUserMbtiGroupStudyList(userId, 8);
+
+        return getGroupStudyListResponses(randomNumber, userId, groupStudyListResponseList, groupStudies);
+    }
+
+
+    private List<GroupStudyListResponse> getGroupStudyListResponses(int randomNumber, Long userId, List<GroupStudyListResponse> groupStudyListResponseList, List<GroupStudy> groupStudies) {
+        for (GroupStudy groupStudy : groupStudies) {
+            boolean isUserLikedThisGroupStudy = isUserLikedThisGroupStudy(userId, groupStudy);
+
+            List<String> groupStudyTagList = getGroupStudyTagList(groupStudy);
+            addGroupStudyResponseToGroupStudyResponseList(randomNumber, groupStudyListResponseList, groupStudy, isUserLikedThisGroupStudy, groupStudyTagList);
+        }
+        return groupStudyListResponseList;
+    }
+
+    private static void addGroupStudyResponseToGroupStudyResponseList(int randomNumber, List<GroupStudyListResponse> groupStudyListResponseList, GroupStudy groupStudy, boolean isUserLikedThisGroupStudy, List<String> groupStudyTagList) {
+        groupStudyListResponseList
+                .add(GroupStudyListResponse.of(groupStudy.getTitle(), groupStudyTagList, randomNumber, isUserLikedThisGroupStudy));
+    }
+
+
+    //        FIXME : 회원이 세션에 몇명 로그인 됐는지 바뀔수 있기 때문에 일단 임시로 랜덤값 삽입
+    private int getRandomNumber() {
+        return ThreadLocalRandom.current().nextInt(100, 1000);
+    }
+
+    private boolean isUserLikedThisGroupStudy(Long userId, GroupStudy groupStudy) {
+        return groupStudyLikeRepository.existsGroupStudyLikeByUserIdAndGroupStudyId(userId, groupStudy.getGroupStudyId());
+    }
+
+    private List<String> getGroupStudyTagList(GroupStudy groupStudy) {
+        return groupStudyTagRepository.findByTagDataByGroupStudyId(groupStudy.getGroupStudyId());
+    }
+
+
+}

--- a/src/main/java/com/team/heyyo/group/study/service/GroupStudyMainPageListService.java
+++ b/src/main/java/com/team/heyyo/group/study/service/GroupStudyMainPageListService.java
@@ -2,10 +2,9 @@ package com.team.heyyo.group.study.service;
 
 import com.team.heyyo.auth.jwt.support.TokenProvider;
 import com.team.heyyo.group.study.domain.GroupStudy;
-import com.team.heyyo.group.study.domain.GroupStudyTag;
-import com.team.heyyo.group.study.dto.GroupStudyResponse;
-import com.team.heyyo.group.study.repository.groupstudylike.GroupStudyLikeRepository;
+import com.team.heyyo.group.study.dto.GroupStudyListResponse;
 import com.team.heyyo.group.study.repository.groupstudy.GroupStudyRepository;
+import com.team.heyyo.group.study.repository.groupstudylike.GroupStudyLikeRepository;
 import com.team.heyyo.group.study.repository.groupstudytag.GroupStudyTagRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,49 +15,52 @@ import java.util.concurrent.ThreadLocalRandom;
 
 @RequiredArgsConstructor
 @Service
-public class GroupStudyService {
+public class GroupStudyMainPageListService {
 
     private final GroupStudyRepository groupStudyRepository;
     private final GroupStudyTagRepository groupStudyTagRepository;
     private final GroupStudyLikeRepository groupStudyLikeRepository;
     private final TokenProvider tokenProvider;
 
-    public List<GroupStudyResponse> getRecentGroupStudyList(String accessToken) {
-
-//        FIXME : 회원이 세션에 몇명 로그인 됐는지 바뀔수 있기 때문에 일단 임시로 랜덤값 삽입
-        int randomNumber = ThreadLocalRandom.current().nextInt(100, 1000);
+    public List<GroupStudyListResponse> getRecentGroupStudyList(String accessToken) {
+        int randomNumber = getRandomNumber();
         Long userId = tokenProvider.getUserId(accessToken);
 
-        List<GroupStudyResponse> groupStudyResponses = new ArrayList<>();
+        List<GroupStudyListResponse> groupStudyListResponseList = new ArrayList<>();
 
         List<GroupStudy> groupStudies = groupStudyRepository.selectRecentGroupStudies();
         for (GroupStudy groupStudy : groupStudies) {
             boolean isUserLikedThisGroupStudy = isUserLikedThisGroupStudy(userId, groupStudy);
 
             List<String> groupStudyTagList = getGroupStudyTagList(groupStudy);
-            groupStudyResponses
-                    .add(GroupStudyResponse.of(groupStudy.getTitle(), groupStudyTagList, randomNumber, isUserLikedThisGroupStudy));
+            groupStudyListResponseList
+                    .add(GroupStudyListResponse.of(groupStudy.getTitle(), groupStudyTagList, randomNumber, isUserLikedThisGroupStudy));
         }
-        return groupStudyResponses;
+        return groupStudyListResponseList;
     }
 
-    public List<GroupStudyResponse> getBestGroupStudyListFromToday(String accessToken) {
-
-        //        FIXME : 회원이 세션에 몇명 로그인 됐는지 바뀔수 있기 때문에 일단 임시로 랜덤값 삽입
-        int randomNumber = ThreadLocalRandom.current().nextInt(100, 1000);
+    public List<GroupStudyListResponse> getBestGroupStudyListFromToday(String accessToken) {
+        int randomNumber = getRandomNumber();
         Long userId = tokenProvider.getUserId(accessToken);
-        List<GroupStudyResponse> groupStudyResponses = new ArrayList<>();
+        List<GroupStudyListResponse> groupStudyListResponseList = new ArrayList<>();
 
         List<GroupStudy> groupStudiesOrderedByMostLikesFromToday = groupStudyRepository.findGroupStudiesOrderedByMostLikesFromToday();
         for (GroupStudy groupStudy : groupStudiesOrderedByMostLikesFromToday) {
             boolean isUserLikedThisGroupStudy = isUserLikedThisGroupStudy(userId, groupStudy);
 
             List<String> groupStudyTagList = getGroupStudyTagList(groupStudy);
-            groupStudyResponses
-                    .add(GroupStudyResponse.of(groupStudy.getTitle(), groupStudyTagList, randomNumber, isUserLikedThisGroupStudy));
+            groupStudyListResponseList
+                    .add(GroupStudyListResponse.of(groupStudy.getTitle(), groupStudyTagList, randomNumber, isUserLikedThisGroupStudy));
         }
-        return groupStudyResponses;
+        return groupStudyListResponseList;
 
+    }
+
+
+
+//        FIXME : 회원이 세션에 몇명 로그인 됐는지 바뀔수 있기 때문에 일단 임시로 랜덤값 삽입
+    private int getRandomNumber() {
+        return ThreadLocalRandom.current().nextInt(100, 1000);
     }
 
 

--- a/src/main/java/com/team/heyyo/user/domain/User.java
+++ b/src/main/java/com/team/heyyo/user/domain/User.java
@@ -54,13 +54,14 @@ public class User implements UserDetails {
     private UserCharacterType characterType;
 
     @Builder
-    public User(String email, String nickname, String password, String name, String phone, UserRole role) {
+    public User(String email, String nickname, String password, String name, String phone, UserRole role, Mbti mbti) {
         this.email = email;
         this.nickname = nickname;
         this.password = password;
         this.name = name;
         this.phone = phone;
         this.role = role;
+        this.mbtiType = mbti;
     }
 
     @Builder

--- a/src/main/resources/static/docs/friend.html
+++ b/src/main/resources/static/docs/friend.html
@@ -602,7 +602,7 @@ Content-Length: 242
   "password" : "password",
   "phone" : "0100000000",
   "mbtiType" : "Focus",
-  "birth" : "2023-08-28T02:38:19.530+00:00",
+  "birth" : "2023-08-28T18:40:29.804+00:00",
   "nickname" : "nickName",
   "characterType" : "고독"
 } ]</code></pre>
@@ -1008,7 +1008,7 @@ Content-Length: 242
   "password" : "password",
   "phone" : "0100000000",
   "mbtiType" : "Focus",
-  "birth" : "2023-08-28T02:38:20.395+00:00",
+  "birth" : "2023-08-28T18:40:30.719+00:00",
   "nickname" : "nickName",
   "characterType" : "고독"
 } ]</code></pre>

--- a/src/main/resources/static/docs/groupStudy.html
+++ b/src/main/resources/static/docs/groupStudy.html
@@ -444,10 +444,19 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div id="toctitle">Table of Contents</div>
 <ul class="sectlevel1">
 <li><a href="#_메인_문서">메인 문서</a></li>
-<li><a href="#_groupstudy_api">GroupStudy API</a>
+<li><a href="#_groupstudy_api">GroupStudy API</a></li>
+<li><a href="#_그룹_공부방0_페이지_api">그룹 공부방0 페이지 API</a>
 <ul class="sectlevel2">
 <li><a href="#_최근에_생긴_그룹공부방_리스트_가져오기_12개">최근에 생긴 그룹공부방 리스트 가져오기 (12개)</a></li>
 <li><a href="#_오늘_하루_좋아요를_가장_많이_받은_리스트_가져오기_12개">오늘 하루 좋아요를 가장 많이 받은 리스트 가져오기 (12개)</a></li>
+</ul>
+</li>
+<li><a href="#_그룹_공부방_페이지_api">그룹 공부방 페이지 API</a>
+<ul class="sectlevel2">
+<li><a href="#_mbti_그룹공부방0_의_키워드와_일치_여기서_앞_영어_부분만_보면_됩니다">MBTI (그룹공부방0 의 키워드와 일치) - 여기서 앞 영어 부분만 보면 됩니다!</a></li>
+<li><a href="#_키워드에_따른_최근에_생긴_그룹_공부방_리스트_가져오기_6개">키워드에 따른 최근에 생긴 그룹 공부방 리스트 가져오기 (6개)</a></li>
+<li><a href="#_키워드에_해당하는_좋아요를_가장_많이_받은_그룹_공부방_리스트_가져오기_6개">키워드에 해당하는 좋아요를 가장 많이 받은 그룹 공부방 리스트 가져오기 (6개)</a></li>
+<li><a href="#_로그인한_사용자의_mbtikeyword_와_반대되는_그룹공부방_리스트_가져오기_8개">로그인한 사용자의 MBTI(keyword) 와 반대되는 그룹공부방 리스트 가져오기 (8개)</a></li>
 </ul>
 </li>
 </ul>
@@ -464,6 +473,12 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </div>
 <div class="sect1">
 <h2 id="_groupstudy_api">GroupStudy API</h2>
+<div class="sectionbody">
+
+</div>
+</div>
+<div class="sect1">
+<h2 id="_그룹_공부방0_페이지_api">그룹 공부방0 페이지 API</h2>
 <div class="sectionbody">
 <div class="sect2">
 <h3 id="_최근에_생긴_그룹공부방_리스트_가져오기_12개">최근에 생긴 그룹공부방 리스트 가져오기 (12개)</h3>
@@ -645,11 +660,366 @@ Content-Length: 207
 </div>
 </div>
 </div>
+<div class="sect1">
+<h2 id="_그룹_공부방_페이지_api">그룹 공부방 페이지 API</h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_mbti_그룹공부방0_의_키워드와_일치_여기서_앞_영어_부분만_보면_됩니다">MBTI (그룹공부방0 의 키워드와 일치) - 여기서 앞 영어 부분만 보면 됩니다!</h3>
+<div class="sect3">
+<h4 id="_앞의_영어부분에_따라서_api에서_mbti_부분에_넣어주시면_됩니다">앞의 영어부분에 따라서 api에서 mbti 부분에 넣어주시면 됩니다.</h4>
+<div class="paragraph">
+<p>Loneliness("고독해요");</p>
+</div>
+<div class="paragraph">
+<p>Communication("소통해요");</p>
+</div>
+<div class="paragraph">
+<p>Crowded("북적해요");</p>
+</div>
+<div class="paragraph">
+<p>Quiet("한산해요");</p>
+</div>
+<div class="paragraph">
+<p>Researching("연구해요");</p>
+</div>
+<div class="paragraph">
+<p>Useful("유익해요");</p>
+</div>
+<div class="paragraph">
+<p>Timid("소심해요");</p>
+</div>
+<div class="paragraph">
+<p>Focus("집중해요");</p>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_키워드에_따른_최근에_생긴_그룹_공부방_리스트_가져오기_6개">키워드에 따른 최근에 생긴 그룹 공부방 리스트 가져오기 (6개)</h3>
+<div class="sect3">
+<h4 id="_request_3">Request</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/group-studies/detail/recent/Focus HTTP/1.1
+Authorization: Bearer accessToken
+Host: localhost:8080</code></pre>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_requestheader">requestHeader</h5>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect4">
+<h5 id="_pathparameter">pathParameter</h5>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /api/group-studies/detail/recent/{mbti}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>mbti</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">해당 키워드 타입</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_3">Response</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 207
+
+[ {
+  "title" : "title1",
+  "tags" : [ "tag1", "tag2" ],
+  "viewerCount" : 100,
+  "liked" : true
+}, {
+  "title" : "title2",
+  "tags" : [ "tag1", "tag2", "tag3" ],
+  "viewerCount" : 200,
+  "liked" : false
+} ]</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">그룹스터디 제목</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].tags[]</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">그룹스터디 태그들</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].viewerCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">그룹스터디 시청자수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].liked</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">현재 사용자가 좋아요를 눌렀는지</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_키워드에_해당하는_좋아요를_가장_많이_받은_그룹_공부방_리스트_가져오기_6개">키워드에 해당하는 좋아요를 가장 많이 받은 그룹 공부방 리스트 가져오기 (6개)</h3>
+<div class="sect3">
+<h4 id="_request_4">Request</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/group-studies/detail/best/Focus HTTP/1.1
+Authorization: Bearer accessToken
+Host: localhost:8080</code></pre>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_pathparameter_2">pathParameter</h5>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 2. /api/group-studies/detail/best/{mbti}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>mbti</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">해당 키워드 타입</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect4">
+<h5 id="_requestheader_2">requestHeader</h5>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_4">Response</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 207
+
+[ {
+  "title" : "title1",
+  "tags" : [ "tag1", "tag2" ],
+  "viewerCount" : 100,
+  "liked" : true
+}, {
+  "title" : "title2",
+  "tags" : [ "tag1", "tag2", "tag3" ],
+  "viewerCount" : 200,
+  "liked" : false
+} ]</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">그룹스터디 제목</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].tags[]</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">그룹스터디 태그들</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].viewerCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">그룹스터디 시청자수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].liked</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">현재 사용자가 좋아요를 눌렀는지</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_로그인한_사용자의_mbtikeyword_와_반대되는_그룹공부방_리스트_가져오기_8개">로그인한 사용자의 MBTI(keyword) 와 반대되는 그룹공부방 리스트 가져오기 (8개)</h3>
+<div class="sect3">
+<h4 id="_request_5">Request</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/group-studies/detail/opposite HTTP/1.1
+Authorization: Bearer accessToken
+Host: localhost:8080</code></pre>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_requestheader_3">requestHeader</h5>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_5">Response</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 207
+
+[ {
+  "title" : "title1",
+  "tags" : [ "tag1", "tag2" ],
+  "viewerCount" : 100,
+  "liked" : true
+}, {
+  "title" : "title2",
+  "tags" : [ "tag1", "tag2", "tag3" ],
+  "viewerCount" : 200,
+  "liked" : false
+} ]</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">그룹스터디 제목</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].tags[]</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">그룹스터디 태그들</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].viewerCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">그룹스터디 시청자수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].liked</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">현재 사용자가 좋아요를 눌렀는지</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-08-27 23:57:32 +0900
+Last updated 2023-08-29 03:39:13 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/main/resources/static/docs/user.html
+++ b/src/main/resources/static/docs/user.html
@@ -601,8 +601,8 @@ Host: localhost:8080
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Set-Cookie: refresh_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ3YW4yZGFhYUBnbWFpbC5jb20iLCJpYXQiOjE2OTMxOTAzMTIsImV4cCI6MTY5NDM5OTkxMiwic3ViIjoiZW1haWwiLCJpZCI6NX0.aZbETFqVu99OAttIosQBR4dg-3jAdYPB8G4AipXN_vM; Path=/; Max-Age=1209600; Expires=Mon, 11 Sep 2023 02:38:32 GMT
-Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ3YW4yZGFhYUBnbWFpbC5jb20iLCJpYXQiOjE2OTMxOTAzMTIsImV4cCI6MTY5MzE5MjExMiwic3ViIjoiZW1haWwiLCJpZCI6NX0._JCbS7exbgElv5IGwZJC8kua7-iOCvKGIjlQ45YHTPQ
+Set-Cookie: refresh_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ3YW4yZGFhYUBnbWFpbC5jb20iLCJpYXQiOjE2OTMyNDgwNDUsImV4cCI6MTY5NDQ1NzY0NSwic3ViIjoiZW1haWwiLCJpZCI6NX0.pbsTmUOBtx174iqnN1sAfFEjB38vP9qxfbeTy7c1uAk; Path=/; Max-Age=1209600; Expires=Mon, 11 Sep 2023 18:40:45 GMT
+Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ3YW4yZGFhYUBnbWFpbC5jb20iLCJpYXQiOjE2OTMyNDgwNDUsImV4cCI6MTY5MzI0OTg0NSwic3ViIjoiZW1haWwiLCJpZCI6NX0.Yn2GW1D382_a-PD7xw8BbxzfPmWVn7yTJfuRjeAclrA
 Content-Type: application/json
 Content-Length: 53
 
@@ -1199,7 +1199,7 @@ Content-Length: 165
 
 {
   "requestId" : "requestId",
-  "requestTime" : "2023-08-28T11:38:33.593567",
+  "requestTime" : "2023-08-29T03:40:46.571092",
   "statusCode" : "202",
   "statusName" : "success",
   "certificationNumber" : 123123
@@ -1314,7 +1314,7 @@ Content-Length: 124
 <h4 id="_request_14">Request</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/users/character-types?_csrf=hD-R4m46V9s23dUvzrCf8am3-RDdAC19zhim_VpXyssBl0sJvVqo0F1bMukb6uYd-Z2rxp2B1HLqYhtQqyyVxWtk-ftj8i8- HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/users/character-types?_csrf=Y-MhIKsBUQ1Lz2MdathVu-twuvqLeR2SeWMtsXGZ7UZRnqh8VoYRRMpnNz1m_1AuXfVh2ooWl8O7GH-_GwIYiEmoiSdkrJxN HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer accessToken
 Content-Length: 36
@@ -1435,7 +1435,7 @@ Content-Length: 63
 <h4 id="_request_15">Request</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/users/character-types?_csrf=vaOY8dld9egofnd2xNdBKcWkoxjKgQnUwZW7xdlBoOVtjBFt2ZSslOFpxN4FH0YUpfp1T6THjnr44jH59aONpup3wYMP7iVe HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/users/character-types?_csrf=-1lelZqf66L0WFbazEwKtvurR458p1kFULaWQz9nuTqraVYsyj06p6OtjsTZYWe7rWE-hcOaau9IxmAoZITzcgde2AieUGcU HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer accessToken
 Content-Length: 36

--- a/src/test/java/com/team/heyyo/group/study/repository/GroupStudyRepositoryTest.java
+++ b/src/test/java/com/team/heyyo/group/study/repository/GroupStudyRepositoryTest.java
@@ -5,6 +5,10 @@ import com.team.heyyo.group.study.domain.GroupStudy;
 import com.team.heyyo.group.study.domain.GroupStudyLike;
 import com.team.heyyo.group.study.repository.groupstudy.GroupStudyRepository;
 import com.team.heyyo.group.study.repository.groupstudylike.GroupStudyLikeRepository;
+import com.team.heyyo.user.constant.Mbti;
+import com.team.heyyo.user.constant.UserRole;
+import com.team.heyyo.user.domain.User;
+import com.team.heyyo.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,6 +30,9 @@ class GroupStudyRepositoryTest {
 
     @Autowired
     GroupStudyLikeRepository groupStudyLikeRepository;
+
+    @Autowired
+    UserRepository userRepository;
 
     @DisplayName("그룹스터디 좋아요 가장많은 순으로 반환한다.")
     @Test
@@ -49,6 +56,80 @@ class GroupStudyRepositoryTest {
         assertThat(groupStudiesOrderedByMostLikes.get(1).getGroupStudyId()).isEqualTo(groupStudy2Id);
         assertThat(groupStudiesOrderedByMostLikes.get(2).getGroupStudyId()).isEqualTo(groupStudy3Id);
         assertThat(groupStudiesOrderedByMostLikes.size()).isEqualTo(12);
+
+    }
+
+    @DisplayName("Mbti 타입에 맞는 그룹스터디를 최신순으로 반환한다.")
+    @Test
+    void selectGroupStudyDetailListWithUserMbti() {
+        //given
+        Mbti mbti = Mbti.Crowded;
+
+        User user = User.builder()
+                .email("email")
+                .name("name")
+                .password("password")
+                .nickname("nickNames")
+                .role(UserRole.USER)
+                .mbti(mbti)
+                .build();
+
+        User sameMbtiUser = User.builder()
+                .email("email2")
+                .name("name2")
+                .password("password2")
+                .nickname("nickNames2")
+                .role(UserRole.USER)
+                .mbti(mbti)
+                .build();
+
+        User differentMbtiUser = User.builder()
+                .email("email3")
+                .name("name3")
+                .password("password3")
+                .nickname("nickNames3")
+                .role(UserRole.USER)
+                .mbti(Mbti.Timid)
+                .build();
+
+        userRepository.save(user);
+        userRepository.save(sameMbtiUser);
+        userRepository.save(differentMbtiUser);
+
+        GroupStudy userGroupStudy = GroupStudy.builder()
+                .userId(user.getUserId())
+                .description("description")
+                .title("title")
+                .session("session")
+                .build();
+
+        GroupStudy sameMbtiUserGroupStudy = GroupStudy.builder()
+                .userId(sameMbtiUser.getUserId())
+                .description("description")
+                .title("title")
+                .session("session")
+                .build();
+
+        GroupStudy differentMbtiUserGroupStudy = GroupStudy.builder()
+                .userId(differentMbtiUser.getUserId())
+                .description("description")
+                .title("title")
+                .session("session")
+                .build();
+
+
+
+        groupStudyRepository.save(userGroupStudy);
+        groupStudyRepository.save(sameMbtiUserGroupStudy);
+        groupStudyRepository.save(differentMbtiUserGroupStudy);
+
+        //when
+        List<GroupStudy> groupStudies = groupStudyRepository.selectRecentGroupStudyDetailListWithMbti(user.getUserId(), mbti, 2);
+
+        //then
+        assertThat(groupStudies).hasSize(2);
+        assertThat(groupStudies.get(0).getUserId()).isEqualTo(user.getUserId());
+        assertThat(groupStudies.get(1).getUserId()).isEqualTo(sameMbtiUser.getUserId());
 
     }
 


### PR DESCRIPTION
## ✔ 지라 이슈 번호
HEY-70

## 📒 작업 내용
- 클래스명이 포괄적이라서 조금더 상세하게 클래스명 수정
- MBTI 별 새로생긴 그룹공부방 리스트 api 구현
- MBTI 별 가장 좋아요를 많이 받은 그룹공부방 리스트 api 구현
- MBTI 와 정반대인 그룹 공부방 리스트 api 구현

## 📢 리뷰어에게 하고 싶은 말
ex) 어디어디를 중점적으로 봐주세요 ...


## 📌 PR 전 체크 사항
- [x] base 브랜치가 **develop** 브랜치로 되어있나요?
- [x] PR title에 PR Type을 표시해 두었나요? (feat:, fix:, refact: ...)
- [x] test가 모두 통과 되었나요? 