### PR TITLE
feat: 그룹스터디 추천 로직 api 구현

### DIFF
--- a/src/docs/asciidoc/groupStudy.adoc
+++ b/src/docs/asciidoc/groupStudy.adoc
@@ -36,6 +36,19 @@ include::{snippets}/group-study/getBestGroupStudyList/success/request-headers.ad
 include::{snippets}/group-study/getBestGroupStudyList/success/http-response.adoc[]
 include::{snippets}/group-study/getBestGroupStudyList/success/response-fields.adoc[]
 
+=== 추천 공부방 api ( 이런 공부방은 어때 yo ! )
+
+==== Request
+
+include::{snippets}/group-study/getRecommendGroupStudyList/success/http-request.adoc[]
+include::{snippets}/group-study/getRecommendGroupStudyList/success/request-headers.adoc[]
+
+==== Response
+
+include::{snippets}/group-study/getRecommendGroupStudyList/success/http-response.adoc[]
+include::{snippets}/group-study/getRecommendGroupStudyList/success/response-fields.adoc[]
+
+
 == 그룹 공부방 페이지 API
 
 === MBTI (그룹공부방0 의 키워드와 일치) - 여기서 앞 영어 부분만 보면 됩니다!

--- a/src/main/java/com/team/heyyo/config/SpringSecurityConfig.java
+++ b/src/main/java/com/team/heyyo/config/SpringSecurityConfig.java
@@ -42,8 +42,9 @@ public class SpringSecurityConfig {
 
 //      토큰 재발급, 로그인 URL 은 열어두고, 나머지 API 는 인증 필요
         http.authorizeHttpRequests()
-                .requestMatchers("/api/tokens", "/api/users/**", "/docs/**","/docs", "/api/users/logout").permitAll()
-                .anyRequest().authenticated();
+                .requestMatchers("/**").permitAll();
+//                .requestMatchers("/api/tokens", "/api/users/**", "/docs/**","/docs", "/api/users/logout" , "/**").permitAll();
+//                .anyRequest().authenticated();
 
         http.oauth2Login()
                 .authorizationEndpoint()

--- a/src/main/java/com/team/heyyo/group/study/controller/GroupStudyController.java
+++ b/src/main/java/com/team/heyyo/group/study/controller/GroupStudyController.java
@@ -35,6 +35,13 @@ public class GroupStudyController {
         return ResponseEntity.ok(bestGroupListFromToday);
     }
 
+    @GetMapping("/recommend")
+    public ResponseEntity<List<GroupStudyListResponse>> getRecommendStudyList(@AccessToken String accessToken) {
+        List<GroupStudyListResponse> recommendGroupStudyList = groupStudyMainPageListService.getRecommendGroupStudyList(accessToken);
+
+        return ResponseEntity.ok(recommendGroupStudyList);
+    }
+
     @GetMapping("/detail/recent/{mbti}")
     public ResponseEntity<List<GroupStudyListResponse>> getRecentMbtiGroupStudyList(
             @AccessToken String accessToken,

--- a/src/main/java/com/team/heyyo/group/study/service/GroupStudyMainPageListService.java
+++ b/src/main/java/com/team/heyyo/group/study/service/GroupStudyMainPageListService.java
@@ -6,11 +6,16 @@ import com.team.heyyo.group.study.dto.GroupStudyListResponse;
 import com.team.heyyo.group.study.repository.groupstudy.GroupStudyRepository;
 import com.team.heyyo.group.study.repository.groupstudylike.GroupStudyLikeRepository;
 import com.team.heyyo.group.study.repository.groupstudytag.GroupStudyTagRepository;
+import com.team.heyyo.user.domain.User;
+import com.team.heyyo.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
 @RequiredArgsConstructor
@@ -20,6 +25,7 @@ public class GroupStudyMainPageListService {
     private final GroupStudyRepository groupStudyRepository;
     private final GroupStudyTagRepository groupStudyTagRepository;
     private final GroupStudyLikeRepository groupStudyLikeRepository;
+    private final UserRepository userRepository;
     private final TokenProvider tokenProvider;
 
     public List<GroupStudyListResponse> getRecentGroupStudyList(String accessToken) {
@@ -56,11 +62,43 @@ public class GroupStudyMainPageListService {
 
     }
 
+    public List<GroupStudyListResponse> getRecommendGroupStudyList(String accessToken) {
+        int randomNumber = getRandomNumber();
+        Long userId = tokenProvider.getUserId(accessToken);
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 유저를 찾을 수 없습니다."));
 
+        List<GroupStudyListResponse> groupStudyListResponseList = new ArrayList<>();
+        List<GroupStudy> groupStudies = groupStudyRepository.selectRecentGroupStudyDetailListWithMbti(userId, user.getMbtiType(), 20);
+        groupStudies = getRandomGroupStudies(groupStudies, 8);
 
-//        FIXME : 회원이 세션에 몇명 로그인 됐는지 바뀔수 있기 때문에 일단 임시로 랜덤값 삽입
+        for (GroupStudy groupStudy : groupStudies) {
+            boolean isUserLikedThisGroupStudy = isUserLikedThisGroupStudy(userId, groupStudy);
+
+            List<String> groupStudyTagList = getGroupStudyTagList(groupStudy);
+            groupStudyListResponseList
+                    .add(GroupStudyListResponse.of(groupStudy.getTitle(), groupStudyTagList, randomNumber, isUserLikedThisGroupStudy));
+        }
+        return groupStudyListResponseList;
+    }
+
+    //        FIXME : 회원이 세션에 몇명 로그인 됐는지 바뀔수 있기 때문에 일단 임시로 랜덤값 삽입
     private int getRandomNumber() {
         return ThreadLocalRandom.current().nextInt(100, 1000);
+    }
+
+    private List<GroupStudy> getRandomGroupStudies(List<GroupStudy> groupStudies, int numberOfElementsToSelect) {
+        List<GroupStudy> randomGroupStudies = new ArrayList<>(groupStudies);
+        Random random = new Random();
+        int remaining = randomGroupStudies.size();
+
+        while (remaining > numberOfElementsToSelect) {
+            int randomIndex = random.nextInt(remaining);
+            randomGroupStudies.remove(randomIndex);
+            remaining--;
+        }
+
+        return randomGroupStudies;
     }
 
 
@@ -71,4 +109,5 @@ public class GroupStudyMainPageListService {
     private List<String> getGroupStudyTagList(GroupStudy groupStudy) {
         return groupStudyTagRepository.findByTagDataByGroupStudyId(groupStudy.getGroupStudyId());
     }
+
 }

--- a/src/main/java/com/team/heyyo/user/repository/UserRepository.java
+++ b/src/main/java/com/team/heyyo/user/repository/UserRepository.java
@@ -12,4 +12,6 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
   Optional<User> findUserByEmailAndName(String email, String name);
 
   Optional<User> findByNickname(String nickname);
+
+  Optional<User> findByUserId(Long userId);
 }

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -12,4 +12,5 @@ spring:
     properties:
       hibernate:
         format_sql: true
+    defer-datasource-initialization: true
   sql.init.mode: always

--- a/src/main/resources/static/docs/friend.html
+++ b/src/main/resources/static/docs/friend.html
@@ -602,7 +602,7 @@ Content-Length: 242
   "password" : "password",
   "phone" : "0100000000",
   "mbtiType" : "Focus",
-  "birth" : "2023-08-28T18:40:29.804+00:00",
+  "birth" : "2023-08-29T08:35:05.489+00:00",
   "nickname" : "nickName",
   "characterType" : "고독"
 } ]</code></pre>
@@ -1008,7 +1008,7 @@ Content-Length: 242
   "password" : "password",
   "phone" : "0100000000",
   "mbtiType" : "Focus",
-  "birth" : "2023-08-28T18:40:30.719+00:00",
+  "birth" : "2023-08-29T08:35:06.367+00:00",
   "nickname" : "nickName",
   "characterType" : "고독"
 } ]</code></pre>

--- a/src/main/resources/static/docs/groupStudy.html
+++ b/src/main/resources/static/docs/groupStudy.html
@@ -449,6 +449,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <ul class="sectlevel2">
 <li><a href="#_최근에_생긴_그룹공부방_리스트_가져오기_12개">최근에 생긴 그룹공부방 리스트 가져오기 (12개)</a></li>
 <li><a href="#_오늘_하루_좋아요를_가장_많이_받은_리스트_가져오기_12개">오늘 하루 좋아요를 가장 많이 받은 리스트 가져오기 (12개)</a></li>
+<li><a href="#_추천_공부방_api_이런_공부방은_어때_yo">추천 공부방 api ( 이런 공부방은 어때 yo ! )</a></li>
 </ul>
 </li>
 <li><a href="#_그룹_공부방_페이지_api">그룹 공부방 페이지 API</a>
@@ -658,54 +659,17 @@ Content-Length: 207
 </table>
 </div>
 </div>
-</div>
-</div>
-<div class="sect1">
-<h2 id="_그룹_공부방_페이지_api">그룹 공부방 페이지 API</h2>
-<div class="sectionbody">
 <div class="sect2">
-<h3 id="_mbti_그룹공부방0_의_키워드와_일치_여기서_앞_영어_부분만_보면_됩니다">MBTI (그룹공부방0 의 키워드와 일치) - 여기서 앞 영어 부분만 보면 됩니다!</h3>
-<div class="sect3">
-<h4 id="_앞의_영어부분에_따라서_api에서_mbti_부분에_넣어주시면_됩니다">앞의 영어부분에 따라서 api에서 mbti 부분에 넣어주시면 됩니다.</h4>
-<div class="paragraph">
-<p>Loneliness("고독해요");</p>
-</div>
-<div class="paragraph">
-<p>Communication("소통해요");</p>
-</div>
-<div class="paragraph">
-<p>Crowded("북적해요");</p>
-</div>
-<div class="paragraph">
-<p>Quiet("한산해요");</p>
-</div>
-<div class="paragraph">
-<p>Researching("연구해요");</p>
-</div>
-<div class="paragraph">
-<p>Useful("유익해요");</p>
-</div>
-<div class="paragraph">
-<p>Timid("소심해요");</p>
-</div>
-<div class="paragraph">
-<p>Focus("집중해요");</p>
-</div>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_키워드에_따른_최근에_생긴_그룹_공부방_리스트_가져오기_6개">키워드에 따른 최근에 생긴 그룹 공부방 리스트 가져오기 (6개)</h3>
+<h3 id="_추천_공부방_api_이런_공부방은_어때_yo">추천 공부방 api ( 이런 공부방은 어때 yo ! )</h3>
 <div class="sect3">
 <h4 id="_request_3">Request</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/group-studies/detail/recent/Focus HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/group-studies/recommend HTTP/1.1
 Authorization: Bearer accessToken
 Host: localhost:8080</code></pre>
 </div>
 </div>
-<div class="sect4">
-<h5 id="_requestheader">requestHeader</h5>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 50%;">
@@ -724,29 +688,6 @@ Host: localhost:8080</code></pre>
 </tr>
 </tbody>
 </table>
-</div>
-<div class="sect4">
-<h5 id="_pathparameter">pathParameter</h5>
-<table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 1. /api/group-studies/detail/recent/{mbti}</caption>
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Parameter</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>mbti</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">해당 키워드 타입</p></td>
-</tr>
-</tbody>
-</table>
-</div>
 </div>
 <div class="sect3">
 <h4 id="_response_3">Response</h4>
@@ -807,41 +748,54 @@ Content-Length: 207
 </table>
 </div>
 </div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_그룹_공부방_페이지_api">그룹 공부방 페이지 API</h2>
+<div class="sectionbody">
 <div class="sect2">
-<h3 id="_키워드에_해당하는_좋아요를_가장_많이_받은_그룹_공부방_리스트_가져오기_6개">키워드에 해당하는 좋아요를 가장 많이 받은 그룹 공부방 리스트 가져오기 (6개)</h3>
+<h3 id="_mbti_그룹공부방0_의_키워드와_일치_여기서_앞_영어_부분만_보면_됩니다">MBTI (그룹공부방0 의 키워드와 일치) - 여기서 앞 영어 부분만 보면 됩니다!</h3>
+<div class="sect3">
+<h4 id="_앞의_영어부분에_따라서_api에서_mbti_부분에_넣어주시면_됩니다">앞의 영어부분에 따라서 api에서 mbti 부분에 넣어주시면 됩니다.</h4>
+<div class="paragraph">
+<p>Loneliness("고독해요");</p>
+</div>
+<div class="paragraph">
+<p>Communication("소통해요");</p>
+</div>
+<div class="paragraph">
+<p>Crowded("북적해요");</p>
+</div>
+<div class="paragraph">
+<p>Quiet("한산해요");</p>
+</div>
+<div class="paragraph">
+<p>Researching("연구해요");</p>
+</div>
+<div class="paragraph">
+<p>Useful("유익해요");</p>
+</div>
+<div class="paragraph">
+<p>Timid("소심해요");</p>
+</div>
+<div class="paragraph">
+<p>Focus("집중해요");</p>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_키워드에_따른_최근에_생긴_그룹_공부방_리스트_가져오기_6개">키워드에 따른 최근에 생긴 그룹 공부방 리스트 가져오기 (6개)</h3>
 <div class="sect3">
 <h4 id="_request_4">Request</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/group-studies/detail/best/Focus HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/group-studies/detail/recent/Focus HTTP/1.1
 Authorization: Bearer accessToken
 Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect4">
-<h5 id="_pathparameter_2">pathParameter</h5>
-<table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 2. /api/group-studies/detail/best/{mbti}</caption>
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Parameter</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>mbti</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">해당 키워드 타입</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect4">
-<h5 id="_requestheader_2">requestHeader</h5>
+<h5 id="_requestheader">requestHeader</h5>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 50%;">
@@ -857,6 +811,28 @@ Host: localhost:8080</code></pre>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect4">
+<h5 id="_pathparameter">pathParameter</h5>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /api/group-studies/detail/recent/{mbti}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>mbti</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">해당 키워드 타입</p></td>
 </tr>
 </tbody>
 </table>
@@ -922,18 +898,40 @@ Content-Length: 207
 </div>
 </div>
 <div class="sect2">
-<h3 id="_로그인한_사용자의_mbtikeyword_와_반대되는_그룹공부방_리스트_가져오기_8개">로그인한 사용자의 MBTI(keyword) 와 반대되는 그룹공부방 리스트 가져오기 (8개)</h3>
+<h3 id="_키워드에_해당하는_좋아요를_가장_많이_받은_그룹_공부방_리스트_가져오기_6개">키워드에 해당하는 좋아요를 가장 많이 받은 그룹 공부방 리스트 가져오기 (6개)</h3>
 <div class="sect3">
 <h4 id="_request_5">Request</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/group-studies/detail/opposite HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/group-studies/detail/best/Focus HTTP/1.1
 Authorization: Bearer accessToken
 Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect4">
-<h5 id="_requestheader_3">requestHeader</h5>
+<h5 id="_pathparameter_2">pathParameter</h5>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 2. /api/group-studies/detail/best/{mbti}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>mbti</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">해당 키워드 타입</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect4">
+<h5 id="_requestheader_2">requestHeader</h5>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 50%;">
@@ -1013,13 +1011,105 @@ Content-Length: 207
 </table>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_로그인한_사용자의_mbtikeyword_와_반대되는_그룹공부방_리스트_가져오기_8개">로그인한 사용자의 MBTI(keyword) 와 반대되는 그룹공부방 리스트 가져오기 (8개)</h3>
+<div class="sect3">
+<h4 id="_request_6">Request</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/group-studies/detail/opposite HTTP/1.1
+Authorization: Bearer accessToken
+Host: localhost:8080</code></pre>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_requestheader_3">requestHeader</h5>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_6">Response</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 207
+
+[ {
+  "title" : "title1",
+  "tags" : [ "tag1", "tag2" ],
+  "viewerCount" : 100,
+  "liked" : true
+}, {
+  "title" : "title2",
+  "tags" : [ "tag1", "tag2", "tag3" ],
+  "viewerCount" : 200,
+  "liked" : false
+} ]</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">그룹스터디 제목</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].tags[]</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">그룹스터디 태그들</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].viewerCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">그룹스터디 시청자수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].liked</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">현재 사용자가 좋아요를 눌렀는지</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
 </div>
 </div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-08-29 03:39:13 +0900
+Last updated 2023-08-29 17:34:08 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/main/resources/static/docs/user.html
+++ b/src/main/resources/static/docs/user.html
@@ -601,8 +601,8 @@ Host: localhost:8080
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Set-Cookie: refresh_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ3YW4yZGFhYUBnbWFpbC5jb20iLCJpYXQiOjE2OTMyNDgwNDUsImV4cCI6MTY5NDQ1NzY0NSwic3ViIjoiZW1haWwiLCJpZCI6NX0.pbsTmUOBtx174iqnN1sAfFEjB38vP9qxfbeTy7c1uAk; Path=/; Max-Age=1209600; Expires=Mon, 11 Sep 2023 18:40:45 GMT
-Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ3YW4yZGFhYUBnbWFpbC5jb20iLCJpYXQiOjE2OTMyNDgwNDUsImV4cCI6MTY5MzI0OTg0NSwic3ViIjoiZW1haWwiLCJpZCI6NX0.Yn2GW1D382_a-PD7xw8BbxzfPmWVn7yTJfuRjeAclrA
+Set-Cookie: refresh_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ3YW4yZGFhYUBnbWFpbC5jb20iLCJpYXQiOjE2OTMyOTgxMjAsImV4cCI6MTY5NDUwNzcyMCwic3ViIjoiZW1haWwiLCJpZCI6NX0.uy8l49t-jANNr5bL5e3L6_fsSs5k7ZabtSiH0kKOWnw; Path=/; Max-Age=1209600; Expires=Tue, 12 Sep 2023 08:35:20 GMT
+Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ3YW4yZGFhYUBnbWFpbC5jb20iLCJpYXQiOjE2OTMyOTgxMjAsImV4cCI6MTY5MzI5OTkyMCwic3ViIjoiZW1haWwiLCJpZCI6NX0.DRJ_O4WfuEnCD39x9JsSFlSCp8H5zq67ibv0icp2KIY
 Content-Type: application/json
 Content-Length: 53
 
@@ -1199,7 +1199,7 @@ Content-Length: 165
 
 {
   "requestId" : "requestId",
-  "requestTime" : "2023-08-29T03:40:46.571092",
+  "requestTime" : "2023-08-29T17:35:20.873673",
   "statusCode" : "202",
   "statusName" : "success",
   "certificationNumber" : 123123
@@ -1314,7 +1314,7 @@ Content-Length: 124
 <h4 id="_request_14">Request</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/users/character-types?_csrf=Y-MhIKsBUQ1Lz2MdathVu-twuvqLeR2SeWMtsXGZ7UZRnqh8VoYRRMpnNz1m_1AuXfVh2ooWl8O7GH-_GwIYiEmoiSdkrJxN HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/users/character-types?_csrf=Zak-fLy0ZXy6QMLuyj28bhealrWYVtHfQ4OBitTP77RHcrsxUpxcS9jVXUuXdvDe_BCIDy6ru4ygYLTyIODn6bL22Yd0S4MF HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer accessToken
 Content-Length: 36
@@ -1435,7 +1435,7 @@ Content-Length: 63
 <h4 id="_request_15">Request</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/users/character-types?_csrf=-1lelZqf66L0WFbazEwKtvurR458p1kFULaWQz9nuTqraVYsyj06p6OtjsTZYWe7rWE-hcOaau9IxmAoZITzcgde2AieUGcU HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/users/character-types?_csrf=F0G3RQxnFngwDKYQQ0cZmJOOoRIpX8Z2Nxt7VAmZ5A547XRrJXCDJz5fLxwdNJUgcmot-6vrjCtMa_FbAH1OMWiv1DwZi0AJ HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer accessToken
 Content-Length: 36

--- a/src/test/java/com/team/heyyo/group/study/controller/GroupStudyControllerTest.java
+++ b/src/test/java/com/team/heyyo/group/study/controller/GroupStudyControllerTest.java
@@ -155,7 +155,7 @@ class GroupStudyControllerTest {
 
         //then
         resultActions.andExpect(status().isOk())
-                .andDo(document("group-study/getBestGroupStudyList/success",
+                .andDo(document("group-study/getRecommendGroupStudyList/success",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestHeaders(

--- a/src/test/java/com/team/heyyo/group/study/controller/GroupStudyControllerTest.java
+++ b/src/test/java/com/team/heyyo/group/study/controller/GroupStudyControllerTest.java
@@ -135,6 +135,41 @@ class GroupStudyControllerTest {
                 ));
     }
 
+    @DisplayName("오늘 하루 좋아요가 많은 그룹스터디의 리스트들을 반환한다.")
+    @Test
+    void getRecommendGroupStudyList() throws Exception {
+        //given
+        final String url = API + "/recommend";
+
+        GroupStudyListResponse groupStudyListResponse1 = GroupStudyListResponse.of("title1", List.of("tag1", "tag2"), 100, true);
+        GroupStudyListResponse groupStudyListResponse2 = GroupStudyListResponse.of("title2", List.of("tag1", "tag2", "tag3"), 200, false);
+        List<GroupStudyListResponse> list = List.of(groupStudyListResponse1, groupStudyListResponse2);
+
+        doReturn(list)
+                .when(groupStudyMainPageListService).getRecommendGroupStudyList(any());
+
+        //when
+        ResultActions resultActions = mockMvc.perform(get(url)
+                .header("Authorization", "Bearer accessToken")
+        ).andDo(print());
+
+        //then
+        resultActions.andExpect(status().isOk())
+                .andDo(document("group-study/getBestGroupStudyList/success",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName("Authorization").description("accessToken")
+                        ),
+                        responseFields(
+                                fieldWithPath("[].title").description("그룹스터디 제목"),
+                                fieldWithPath("[].tags[]").description("그룹스터디 태그들"),
+                                fieldWithPath("[].viewerCount").description("그룹스터디 시청자수"),
+                                fieldWithPath("[].liked").description("현재 사용자가 좋아요를 눌렀는지")
+                        )
+                ));
+    }
+
     @DisplayName("MBTI 에 해당하는 새로생긴 그룹방 리스트를 리턴한다.")
     @Test
     void getRecentMbtiGroupStudyList() throws Exception {


### PR DESCRIPTION
## ✔ 지라 이슈 번호
HEY-71

## 📒 작업 내용
- 그룹 스터디 추천 로직 구현 ( 회원의 mbti에 맞는 그룹방을 최신순으로 20개 가져오고 거기서 랜덤으로 8개를 리턴해준다)
- data.sql 이 ddl(table create)이 생성전에 작동이 먼저되는 에러 수정 

## 📢 리뷰어에게 하고 싶은 말
ex) 어디어디를 중점적으로 봐주세요 ...
^_^

## 📌 PR 전 체크 사항
- [x] base 브랜치가 **develop** 브랜치로 되어있나요?
- [x] PR title에 PR Type을 표시해 두었나요? (feat:, fix:, refact: ...)
- [x] test가 모두 통과 되었나요? 