### PR TITLE
fix: 그룹스터디 상세페이지 로직 수정

### DIFF
--- a/src/main/java/com/team/heyyo/group/study/domain/GroupStudy.java
+++ b/src/main/java/com/team/heyyo/group/study/domain/GroupStudy.java
@@ -1,5 +1,6 @@
 package com.team.heyyo.group.study.domain;
 
+import com.team.heyyo.user.constant.Mbti;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -27,14 +28,18 @@ public class GroupStudy {
 
     private String session;
 
+    @Enumerated(EnumType.STRING)
+    private Mbti mbti;
+
     @CreatedDate
     private LocalDateTime createdAt;
 
     @Builder
-    public GroupStudy(Long userId, String title, String description, String session) {
+    public GroupStudy(Long userId, String title, String description, String session, Mbti mbti) {
         this.userId = userId;
         this.title = title;
         this.description = description;
         this.session = session;
+        this.mbti = mbti;
     }
 }

--- a/src/main/java/com/team/heyyo/group/study/dto/GroupStudyListResponse.java
+++ b/src/main/java/com/team/heyyo/group/study/dto/GroupStudyListResponse.java
@@ -3,7 +3,7 @@ package com.team.heyyo.group.study.dto;
 import lombok.*;
 
 import java.util.List;
-
+//FIXME : 좋아요 수 리턴하는 로직 추가 구현 필요
 @ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -19,4 +19,9 @@ public class GroupStudyListResponse {
     public static GroupStudyListResponse of(String title, List<String> tags, int viewerCount, boolean isLiked) {
         return new GroupStudyListResponse(title, tags, viewerCount, isLiked);
     }
+
+    public static GroupStudyListResponse of(String title, List<String> tags, int viewerCount) {
+        return new GroupStudyListResponse(title, tags, viewerCount, true);
+    }
+
 }

--- a/src/main/java/com/team/heyyo/group/study/repository/groupstudy/GroupStudyRepositoryCustom.java
+++ b/src/main/java/com/team/heyyo/group/study/repository/groupstudy/GroupStudyRepositoryCustom.java
@@ -9,7 +9,7 @@ public interface GroupStudyRepositoryCustom {
     public List<GroupStudy> selectRecentGroupStudies();
 
     public List<GroupStudy> findGroupStudiesOrderedByMostLikesFromToday();
-    public List<GroupStudy> selectRecentGroupStudyDetailListWithMbti(Long userId, Mbti mbti, int limit);
+    public List<GroupStudy> selectRecentGroupStudyDetailListWithMbti(Mbti mbti, int limit);
 
     List<GroupStudy> selectMostLikeGroupStudyDetailListWithMbti(Long userId, Mbti mbti, int limit);
 

--- a/src/main/java/com/team/heyyo/group/study/repository/groupstudy/GroupStudyRepositoryImpl.java
+++ b/src/main/java/com/team/heyyo/group/study/repository/groupstudy/GroupStudyRepositoryImpl.java
@@ -47,14 +47,9 @@ public class GroupStudyRepositoryImpl implements GroupStudyRepositoryCustom {
     }
 
     @Override
-    public List<GroupStudy> selectRecentGroupStudyDetailListWithMbti(Long userId, Mbti mbti, int limit) {
+    public List<GroupStudy> selectRecentGroupStudyDetailListWithMbti(Mbti mbti, int limit) {
         return queryFactory.selectFrom(groupStudy)
-                .where(
-                        select(user.mbtiType)
-                                .from(user)
-                                .where(user.userId.eq(groupStudy.userId))
-                                .eq(mbti)
-                )
+                .where(groupStudy.mbti.eq(mbti))
                 .orderBy(groupStudy.createdAt.desc())
                 .limit(limit)
                 .fetch();

--- a/src/main/java/com/team/heyyo/group/study/service/GroupStudyDetailPageListService.java
+++ b/src/main/java/com/team/heyyo/group/study/service/GroupStudyDetailPageListService.java
@@ -14,6 +14,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
+
+// FIXME 그룹공부방 당 좋아요 수 로직 추가 핋요
 @RequiredArgsConstructor
 @Service
 public class GroupStudyDetailPageListService {
@@ -28,7 +30,7 @@ public class GroupStudyDetailPageListService {
         Long userId = tokenProvider.getUserId(accessToken);
 
         List<GroupStudyListResponse> groupStudyListResponseList = new ArrayList<>();
-        List<GroupStudy> groupStudies = groupStudyRepository.selectRecentGroupStudyDetailListWithMbti(userId, mbti, 6);
+        List<GroupStudy> groupStudies = groupStudyRepository.selectRecentGroupStudyDetailListWithMbti(mbti, 6);
 
         return getGroupStudyListResponses(randomNumber, userId, groupStudyListResponseList, groupStudies);
     }
@@ -66,7 +68,7 @@ public class GroupStudyDetailPageListService {
 
     private static void addGroupStudyResponseToGroupStudyResponseList(int randomNumber, List<GroupStudyListResponse> groupStudyListResponseList, GroupStudy groupStudy, boolean isUserLikedThisGroupStudy, List<String> groupStudyTagList) {
         groupStudyListResponseList
-                .add(GroupStudyListResponse.of(groupStudy.getTitle(), groupStudyTagList, randomNumber, isUserLikedThisGroupStudy));
+            .add(GroupStudyListResponse.of(groupStudy.getTitle(), groupStudyTagList, randomNumber, isUserLikedThisGroupStudy));
     }
 
 

--- a/src/main/java/com/team/heyyo/group/study/service/GroupStudyMainPageListService.java
+++ b/src/main/java/com/team/heyyo/group/study/service/GroupStudyMainPageListService.java
@@ -35,12 +35,11 @@ public class GroupStudyMainPageListService {
         List<GroupStudyListResponse> groupStudyListResponseList = new ArrayList<>();
 
         List<GroupStudy> groupStudies = groupStudyRepository.selectRecentGroupStudies();
-        for (GroupStudy groupStudy : groupStudies) {
-            boolean isUserLikedThisGroupStudy = isUserLikedThisGroupStudy(userId, groupStudy);
 
+        for (GroupStudy groupStudy : groupStudies) {
             List<String> groupStudyTagList = getGroupStudyTagList(groupStudy);
             groupStudyListResponseList
-                    .add(GroupStudyListResponse.of(groupStudy.getTitle(), groupStudyTagList, randomNumber, isUserLikedThisGroupStudy));
+                    .add(GroupStudyListResponse.of(groupStudy.getTitle(), groupStudyTagList, randomNumber));
         }
         return groupStudyListResponseList;
     }
@@ -69,7 +68,7 @@ public class GroupStudyMainPageListService {
                 .orElseThrow(() -> new EntityNotFoundException("해당 유저를 찾을 수 없습니다."));
 
         List<GroupStudyListResponse> groupStudyListResponseList = new ArrayList<>();
-        List<GroupStudy> groupStudies = groupStudyRepository.selectRecentGroupStudyDetailListWithMbti(userId, user.getMbtiType(), 20);
+        List<GroupStudy> groupStudies = groupStudyRepository.selectRecentGroupStudyDetailListWithMbti(user.getMbtiType(), 20);
         groupStudies = getRandomGroupStudies(groupStudies, 8);
 
         for (GroupStudy groupStudy : groupStudies) {

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,46 +1,205 @@
 insert into user_tb (email, password, nickname, name)
 values ('test@naver.com', '$2y$10$A.GI9LepwCc9hLaNQX8xnOOULfUH.so1tZ3L7fbEg701GsBfPFTsi', '테스트닉네임', '테스트이름');
 
-insert into group_study_tb (owner_user_id, title, description, session, created_at)
-values (1, 'test1', 'description1', 'session', now());
-insert into group_study_tb (owner_user_id, title, description, session, created_at)
-values (1, 'test2', 'description2', 'session', now());
-insert into group_study_tb (owner_user_id, title, description, session, created_at)
-values (1, 'test3', 'description3', 'session', now());
-insert into group_study_tb (owner_user_id, title, description, session, created_at)
-values (1, 'test4', 'description4', 'session', now());
-insert into group_study_tb (owner_user_id, title, description, session, created_at)
-values (1, 'test5', 'description5', 'session', now());
-insert into group_study_tb (owner_user_id, title, description, session, created_at)
-values (1, 'test6', 'description6', 'session', now());
-insert into group_study_tb (owner_user_id, title, description, session, created_at)
-values (1, 'test7', 'description7', 'session', now());
-insert into group_study_tb (owner_user_id, title, description, session, created_at)
-values (1, 'test8', 'description8', 'session', now());
-insert into group_study_tb (owner_user_id, title, description, session, created_at)
-values (1, 'test9', 'description9', 'session', now());
-insert into group_study_tb (owner_user_id, title, description, session, created_at)
-values (1, 'test10', 'description10', 'session', now());
-insert into group_study_tb (owner_user_id, title, description, session, created_at)
-values (1, 'test11', 'description11', 'session', now());
-insert into group_study_tb (owner_user_id, title, description, session, created_at)
-values (1, 'test12', 'description12', 'session', now());
-insert into group_study_tb (owner_user_id, title, description, session, created_at)
-values (1, 'test13', 'description13', 'session', now());
-insert into group_study_tb (owner_user_id, title, description, session, created_at)
-values (1, 'test14', 'description14', 'session', now());
-insert into group_study_tb (owner_user_id, title, description, session, created_at)
-values (1, 'test15', 'description15', 'session', now());
-insert into group_study_tb (owner_user_id, title, description, session, created_at)
-values (1, 'test16', 'description16', 'session', now());
-insert into group_study_tb (owner_user_id, title, description, session, created_at)
-values (1, 'test17', 'description17', 'session', now());
-insert into group_study_tb (owner_user_id, title, description, session, created_at)
-values (1, 'test18', 'description18', 'session', now());
-insert into group_study_tb (owner_user_id, title, description, session, created_at)
-values (1, 'test19', 'description19', 'session', now());
-insert into group_study_tb (owner_user_id, title, description, session, created_at)
-values (1, 'test20', 'description20', 'session', now());
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test1', 'description1', 'session', now(), 'Loneliness');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test2', 'description2', 'session', now(), 'Loneliness');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test3', 'description3', 'session', now(), 'Loneliness');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test3', 'description3', 'session', now(), 'Loneliness');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test3', 'description3', 'session', now(), 'Loneliness');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test3', 'description3', 'session', now(), 'Loneliness');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test3', 'description3', 'session', now(), 'Loneliness');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test3', 'description3', 'session', now(), 'Loneliness');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test3', 'description3', 'session', now(), 'Loneliness');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test3', 'description3', 'session', now(), 'Loneliness');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test3', 'description3', 'session', now(), 'Loneliness');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test3', 'description3', 'session', now(), 'Loneliness');
+
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test4', 'description4', 'session', now(), 'Crowded');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test5', 'description5', 'session', now(), 'Crowded');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test5', 'description5', 'session', now(), 'Crowded');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test5', 'description5', 'session', now(), 'Crowded');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test5', 'description5', 'session', now(), 'Crowded');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test5', 'description5', 'session', now(), 'Crowded');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test5', 'description5', 'session', now(), 'Crowded');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test5', 'description5', 'session', now(), 'Crowded');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test5', 'description5', 'session', now(), 'Crowded');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test5', 'description5', 'session', now(), 'Crowded');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test5', 'description5', 'session', now(), 'Crowded');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test5', 'description5', 'session', now(), 'Crowded');
+
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test6', 'description6', 'session', now(), 'Communication');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test7', 'description7', 'session', now(), 'Communication');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test7', 'description7', 'session', now(), 'Communication');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test7', 'description7', 'session', now(), 'Communication');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test7', 'description7', 'session', now(), 'Communication');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test7', 'description7', 'session', now(), 'Communication');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test7', 'description7', 'session', now(), 'Communication');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test7', 'description7', 'session', now(), 'Communication');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test7', 'description7', 'session', now(), 'Communication');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test7', 'description7', 'session', now(), 'Communication');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test7', 'description7', 'session', now(), 'Communication');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test7', 'description7', 'session', now(), 'Communication');
+
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test8', 'description8', 'session', now(), 'Quiet');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test9', 'description9', 'session', now(), 'Quiet');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test8', 'description8', 'session', now(), 'Quiet');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test9', 'description9', 'session', now(), 'Quiet');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test8', 'description8', 'session', now(), 'Quiet');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test9', 'description9', 'session', now(), 'Quiet');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test8', 'description8', 'session', now(), 'Quiet');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test9', 'description9', 'session', now(), 'Quiet');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test8', 'description8', 'session', now(), 'Quiet');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test9', 'description9', 'session', now(), 'Quiet');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test8', 'description8', 'session', now(), 'Quiet');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test9', 'description9', 'session', now(), 'Quiet');
+
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test10', 'description10', 'session', now(), 'Researching');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test11', 'description11', 'session', now(), 'Researching');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test10', 'description10', 'session', now(), 'Researching');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test11', 'description11', 'session', now(), 'Researching');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test10', 'description10', 'session', now(), 'Researching');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test11', 'description11', 'session', now(), 'Researching');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test10', 'description10', 'session', now(), 'Researching');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test11', 'description11', 'session', now(), 'Researching');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test10', 'description10', 'session', now(), 'Researching');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test11', 'description11', 'session', now(), 'Researching');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test10', 'description10', 'session', now(), 'Researching');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test11', 'description11', 'session', now(), 'Researching');
+
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test12', 'description12', 'session', now(), 'Useful');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test13', 'description13', 'session', now(), 'Useful');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test12', 'description12', 'session', now(), 'Useful');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test13', 'description13', 'session', now(), 'Useful');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test12', 'description12', 'session', now(), 'Useful');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test13', 'description13', 'session', now(), 'Useful');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test12', 'description12', 'session', now(), 'Useful');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test13', 'description13', 'session', now(), 'Useful');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test12', 'description12', 'session', now(), 'Useful');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test13', 'description13', 'session', now(), 'Useful');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test12', 'description12', 'session', now(), 'Useful');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test13', 'description13', 'session', now(), 'Useful');
+
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test14', 'description14', 'session', now(), 'Timid');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test15', 'description15', 'session', now(), 'Timid');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test14', 'description14', 'session', now(), 'Timid');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test15', 'description15', 'session', now(), 'Timid');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test14', 'description14', 'session', now(), 'Timid');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test15', 'description15', 'session', now(), 'Timid');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test14', 'description14', 'session', now(), 'Timid');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test15', 'description15', 'session', now(), 'Timid');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test14', 'description14', 'session', now(), 'Timid');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test15', 'description15', 'session', now(), 'Timid');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test14', 'description14', 'session', now(), 'Timid');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test15', 'description15', 'session', now(), 'Timid');
+
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test16', 'description16', 'session', now(), 'Focus');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test17', 'description17', 'session', now(), 'Focus');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test16', 'description16', 'session', now(), 'Focus');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test17', 'description17', 'session', now(), 'Focus');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test16', 'description16', 'session', now(), 'Focus');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test17', 'description17', 'session', now(), 'Focus');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test16', 'description16', 'session', now(), 'Focus');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test17', 'description17', 'session', now(), 'Focus');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test16', 'description16', 'session', now(), 'Focus');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test17', 'description17', 'session', now(), 'Focus');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test16', 'description16', 'session', now(), 'Focus');
+insert into group_study_tb (owner_user_id, title, description, session, created_at, mbti)
+values (1, 'test17', 'description17', 'session', now(), 'Focus');
 
 insert into group_study_like_tb (group_study_id, created_at)
 values (1, now());

--- a/src/main/resources/static/docs/friend.html
+++ b/src/main/resources/static/docs/friend.html
@@ -593,7 +593,7 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 238
+Content-Length: 212
 
 [ {
   "userId" : 10,
@@ -602,9 +602,8 @@ Content-Length: 238
   "password" : "password",
   "phone" : "0100000000",
   "mbtiType" : "Focus",
-  "birth" : "2023-09-01T08:31:56.537+00:00",
-  "nickname" : "nickName",
-  "characterType" : null
+  "birth" : "2023-09-02T08:03:57.095+00:00",
+  "nickname" : "nickName"
 } ]</code></pre>
 </div>
 </div>
@@ -636,11 +635,6 @@ Content-Length: 238
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>[]phone</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">핸드폰 번호</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].characterType</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">캐릭터 타입</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].email</code></p></td>
@@ -999,7 +993,7 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 238
+Content-Length: 212
 
 [ {
   "userId" : 10,
@@ -1008,9 +1002,8 @@ Content-Length: 238
   "password" : "password",
   "phone" : "0100000000",
   "mbtiType" : "Focus",
-  "birth" : "2023-09-01T08:31:57.462+00:00",
-  "nickname" : "nickName",
-  "characterType" : null
+  "birth" : "2023-09-02T08:03:57.984+00:00",
+  "nickname" : "nickName"
 } ]</code></pre>
 </div>
 </div>
@@ -1042,11 +1035,6 @@ Content-Length: 238
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].phone</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">핸드폰 번호</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].characterType</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">캐릭터 타입</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].email</code></p></td>

--- a/src/main/resources/static/docs/settings.html
+++ b/src/main/resources/static/docs/settings.html
@@ -541,7 +541,7 @@ Host: localhost:8080
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 221
+Content-Length: 195
 
 {
   "userId" : null,
@@ -552,8 +552,7 @@ Content-Length: 221
   "phone" : null,
   "mbtiType" : null,
   "birth" : null,
-  "isMarketingAgree" : null,
-  "characterType" : null
+  "isMarketingAgree" : null
 }</code></pre>
 </div>
 </div>
@@ -602,24 +601,19 @@ Content-Length: 221
 <td class="tableblock halign-left valign-top"><p class="tableblock">사용자 phone</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>mbtiType</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">MBTI 타입</p></td>
-</tr>
-<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>birth</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">출생일</p></td>
 </tr>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>mbtiType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">MBTI 타입</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>isMarketingAgree</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">마케팅 동의 여부</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>characterType</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">캐릭터 타입</p></td>
 </tr>
 </tbody>
 </table>

--- a/src/main/resources/static/docs/user.html
+++ b/src/main/resources/static/docs/user.html
@@ -601,8 +601,8 @@ Host: localhost:8080
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Set-Cookie: refresh_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ3YW4yZGFhYUBnbWFpbC5jb20iLCJpYXQiOjE2OTM1NTcxMzIsImV4cCI6MTY5NDc2NjczMiwic3ViIjoiZW1haWwiLCJpZCI6NX0.zFas8NC815pi-wZ1Y05wkmaVGkdGmNdjlBhtl4PfCBo; Path=/; Max-Age=1209600; Expires=Fri, 15 Sep 2023 08:32:12 GMT
-Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ3YW4yZGFhYUBnbWFpbC5jb20iLCJpYXQiOjE2OTM1NTcxMzIsImV4cCI6MTY5MzU1ODkzMiwic3ViIjoiZW1haWwiLCJpZCI6NX0.PlhK4dFotYRFE9CB_TY9j0LlmQ--Jx1ZgoND-P810s0
+Set-Cookie: refresh_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ3YW4yZGFhYUBnbWFpbC5jb20iLCJpYXQiOjE2OTM2NDE4NTUsImV4cCI6MTY5NDg1MTQ1NSwic3ViIjoiZW1haWwiLCJpZCI6NX0.fH3G0B4P7MPI9p_QEtFJZszksdcFBfKHUfAeK1ZNLHU; Path=/; Max-Age=1209600; Expires=Sat, 16 Sep 2023 08:04:15 GMT
+Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ3YW4yZGFhYUBnbWFpbC5jb20iLCJpYXQiOjE2OTM2NDE4NTUsImV4cCI6MTY5MzY0MzY1NSwic3ViIjoiZW1haWwiLCJpZCI6NX0.MO3IaoEeD4S2Vf9P4GAqye2KhGHbFpezq9l0j3nunKA
 Content-Type: application/json
 Content-Length: 53
 
@@ -1199,7 +1199,7 @@ Content-Length: 165
 
 {
   "requestId" : "requestId",
-  "requestTime" : "2023-09-01T17:32:13.146744",
+  "requestTime" : "2023-09-02T17:04:15.993948",
   "statusCode" : "202",
   "statusName" : "success",
   "certificationNumber" : 123123
@@ -1314,7 +1314,7 @@ Content-Length: 124
 <h4 id="_request_14">Request</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/users/character-types?_csrf=stl5a4oxOlcS79xzvwUa0IaMVEDUIB8oTfz66tn6X6M--ddTirtPXLsBXm4_iuRB3igu6ODoeSK2RCsFKZ2bjurKZsVcneNi HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/users/character-types?_csrf=5MeN5gS3QgOMm2WCHA6fQ9651gjdDAixrpHFbHoxmTam32o41_Du0jbSdGehrVDkKiOrdumM-zG8NWyczfWkXEtU-AHE7gha HTTP/1.1
 Content-Type: application/json
 Authorization: Bearer accessToken
 Content-Length: 22
@@ -1429,7 +1429,7 @@ Content-Length: 63
 <h4 id="_request_15">Request</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/users/character-types?_csrf=KqyAPHJzORAivYjLTDo-V_Ur64vVvAhKkfAZN-w097pFiC5hH8q3ChEQXSIPhLz5LRcKZsdKxrLs3zhnosh6AYoHwY0juUoD HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/users/character-types?_csrf=3Kh47vgLYtYX37i-Ab6m8UjVSuZObpWnh7GiozQUgCCvH8jQ6s0Z3MtpA-I65o3cYpOSyX_kZ98sXPOK4YiRkwYssBOWKaro HTTP/1.1
 Content-Type: application/json
 Authorization: Bearer accessToken
 Content-Length: 22

--- a/src/test/java/com/team/heyyo/group/study/repository/GroupStudyRepositoryTest.java
+++ b/src/test/java/com/team/heyyo/group/study/repository/GroupStudyRepositoryTest.java
@@ -101,6 +101,7 @@ class GroupStudyRepositoryTest {
                 .description("description")
                 .title("title")
                 .session("session")
+                .mbti(mbti)
                 .build();
 
         GroupStudy sameMbtiUserGroupStudy = GroupStudy.builder()
@@ -108,6 +109,7 @@ class GroupStudyRepositoryTest {
                 .description("description")
                 .title("title")
                 .session("session")
+                .mbti(mbti)
                 .build();
 
         GroupStudy differentMbtiUserGroupStudy = GroupStudy.builder()
@@ -115,6 +117,7 @@ class GroupStudyRepositoryTest {
                 .description("description")
                 .title("title")
                 .session("session")
+                .mbti(Mbti.Communication)
                 .build();
 
 
@@ -124,12 +127,10 @@ class GroupStudyRepositoryTest {
         groupStudyRepository.save(differentMbtiUserGroupStudy);
 
         //when
-        List<GroupStudy> groupStudies = groupStudyRepository.selectRecentGroupStudyDetailListWithMbti(user.getUserId(), mbti, 2);
+        List<GroupStudy> groupStudies = groupStudyRepository.selectRecentGroupStudyDetailListWithMbti(mbti, 2);
 
         //then
         assertThat(groupStudies).hasSize(2);
-        assertThat(groupStudies.get(0).getUserId()).isEqualTo(user.getUserId());
-        assertThat(groupStudies.get(1).getUserId()).isEqualTo(sameMbtiUser.getUserId());
 
     }
 


### PR DESCRIPTION
## ✔ 지라 이슈 번호
HEY-78


## 📒 작업 내용
- 기존 로직은 그룹스터디의 user의 mbti를 가져왔는데,
그룹스터디 별 mbti가 생성시 추가해주어서 그룹스터디 엔티티에 mbti 컬럼 추가 후 가져오게 로직 수정

## 📢 리뷰어에게 하고 싶은 말
ex) 어디어디를 중점적으로 봐주세요 ...


## 📌 PR 전 체크 사항
- [x] base 브랜치가 **develop** 브랜치로 되어있나요?
- [x] PR title에 PR Type을 표시해 두었나요? (feat:, fix:, refact: ...)
- [x] test가 모두 통과 되었나요? 